### PR TITLE
Incorporate more of VHDLParsing into Machine Structure

### DIFF
--- a/Sources/VHDLMachines/State.swift
+++ b/Sources/VHDLMachines/State.swift
@@ -22,7 +22,7 @@ public struct State: Codable, Equatable, Hashable, Sendable {
 
     /// The name of the external variables accessed in the state. These variables are defined
     /// in the arrangement.
-    public var externalVariables: [String]
+    public var externalVariables: [VariableName]
 
     /// Initialises a state with the given properties.
     /// - Parameters:
@@ -40,7 +40,7 @@ public struct State: Codable, Equatable, Hashable, Sendable {
         name: VariableName,
         actions: [ActionName: SynchronousBlock],
         signals: [LocalSignal],
-        externalVariables: [String]
+        externalVariables: [VariableName]
     ) {
         self.name = name
         self.actions = actions

--- a/Sources/VHDLMachines/codeStructure/MachineVHDLRepresentable.swift
+++ b/Sources/VHDLMachines/codeStructure/MachineVHDLRepresentable.swift
@@ -74,4 +74,7 @@ public protocol MachineVHDLRepresentable {
     /// The includes required by the ``Machine``.
     var includes: [Include] { get }
 
+    /// The machine to represent.
+    var machine: Machine { get }
+
 }

--- a/Tests/VHDLMachinesTests/PingPongArrangement.swift
+++ b/Tests/VHDLMachinesTests/PingPongArrangement.swift
@@ -126,7 +126,7 @@ struct PingPongArrangement {
             name: VariableName(rawValue: "Ping")!,
             actions: pingActions,
             signals: [],
-            externalVariables: ["ping", "pong"]
+            externalVariables: [.ping, .pong]
         )
     }
 
@@ -136,7 +136,7 @@ struct PingPongArrangement {
             name: VariableName(rawValue: "Pong")!,
             actions: pongActions,
             signals: [],
-            externalVariables: ["ping", "pong"]
+            externalVariables: [.ping, .pong]
         )
     }
 
@@ -207,7 +207,7 @@ struct PingPongArrangement {
             isParameterised: false,
             parameterSignals: [],
             returnableSignals: [],
-            states: [pingState, checkState(externalVariables: ["pong"], reset: "ping")],
+            states: [pingState, checkState(externalVariables: [.pong], reset: "ping")],
             transitions: [pingTransition, pingWaitTransition],
             initialState: 0,
             suspendedState: nil
@@ -229,7 +229,7 @@ struct PingPongArrangement {
             isParameterised: false,
             parameterSignals: [],
             returnableSignals: [],
-            states: [checkState(externalVariables: ["ping"], reset: "pong"), pongState],
+            states: [checkState(externalVariables: [.ping], reset: "pong"), pongState],
             transitions: [pongWaitTransition, pongTransition],
             initialState: 0,
             suspendedState: nil
@@ -346,7 +346,7 @@ struct PingPongArrangement {
     ///   - externalVariables: The variables to check.
     ///   - reset: What to reset.
     /// - Returns: The check state.
-    func checkState(externalVariables: [String], reset: String) -> State {
+    func checkState(externalVariables: [VariableName], reset: String) -> State {
         State(
             name: VariableName(rawValue: "Check")!,
             actions: emptyActions(reset: reset),

--- a/Tests/VHDLMachinesTests/StateTests.swift
+++ b/Tests/VHDLMachinesTests/StateTests.swift
@@ -86,8 +86,9 @@ final class StateTests: XCTestCase {
     }
 
     /// The external variables.
-    var externalVariables: [String] {
-        ["A"]
+    var externalVariables: [VariableName] {
+        // swiftlint:disable:next force_unwrapping
+        [VariableName(rawValue: "A")!]
     }
 
     /// The state to test.
@@ -155,8 +156,10 @@ final class StateTests: XCTestCase {
                 )
             ]
         )
-        self.state.externalVariables = ["B"]
-        XCTAssertEqual(self.state.externalVariables, ["B"])
+        // swiftlint:disable:next force_unwrapping
+        let b = VariableName(rawValue: "B")!
+        self.state.externalVariables = [b]
+        XCTAssertEqual(self.state.externalVariables, [b])
     }
 
 }

--- a/Tests/VHDLMachinesTests/VariableName+testConstants.swift
+++ b/Tests/VHDLMachinesTests/VariableName+testConstants.swift
@@ -91,6 +91,10 @@ extension VariableName {
 
     static var parX: VariableName { VariableName(rawValue: "parX")! }
 
+    static var ping: VariableName { VariableName(rawValue: "ping")! }
+
+    static var pong: VariableName { VariableName(rawValue: "pong")! }
+
     static var parXs: VariableName { VariableName(rawValue: "parXs")! }
 
     static var retX: VariableName { VariableName(rawValue: "retX")! }


### PR DESCRIPTION
This PR forces external variables in state declarations to use the `VariableName` type from `VHDLParsing`. This PR also adds a `machine` property to `MachineVHDLRepresentable`.