### PR TITLE
Add support for VHDLParsing 2.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mipalgu/VHDLParsing",
       "state" : {
-        "revision" : "619687303b8e68c2d5a8919b3f72edf0f942c8bf",
-        "version" : "1.1.1"
+        "revision" : "5612793c14b65b513c742642844093ac0bec1463",
+        "version" : "2.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "1.1.1"),
+        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "2.0.0"),
         .package(url: "https://github.com/mipalgu/GUUnits", from: "2.1.0"),
         .package(url: "https://github.com/mipalgu/swift_helpers", from: "2.0.0"),
         .package(url: "https://github.com/mipalgu/LLFSMModel", from: "1.0.0")

--- a/Sources/ModelImports/Machine+machineInit.swift
+++ b/Sources/ModelImports/Machine+machineInit.swift
@@ -77,8 +77,8 @@ extension VHDLMachines.Machine {
             let parameters = [Parameter](convert: machine.parameters),
             let returnables = [ReturnableVariable](convert: machine.returnables),
             let ieee = VariableName(rawValue: "IEEE"),
-            let stdLogicImport = UseStatement(rawValue: "IEEE.std_logic_1164.all"),
-            let mathRealImport = UseStatement(rawValue: "IEEE.math_real.all")
+            let stdLogicImport = UseStatement(rawValue: "use IEEE.std_logic_1164.all;"),
+            let mathRealImport = UseStatement(rawValue: "use IEEE.math_real.all;")
         else {
             return nil
         }

--- a/Sources/ModelImports/Machine+machineInit.swift
+++ b/Sources/ModelImports/Machine+machineInit.swift
@@ -75,7 +75,10 @@ extension VHDLMachines.Machine {
             let clocks = [Clock](convert: machine.globalVariables),
             !clocks.isEmpty,
             let parameters = [Parameter](convert: machine.parameters),
-            let returnables = [ReturnableVariable](convert: machine.returnables)
+            let returnables = [ReturnableVariable](convert: machine.returnables),
+            let ieee = VariableName(rawValue: "IEEE"),
+            let stdLogicImport = UseStatement(rawValue: "IEEE.std_logic_1164.all"),
+            let mathRealImport = UseStatement(rawValue: "IEEE.math_real.all")
         else {
             return nil
         }
@@ -106,9 +109,9 @@ extension VHDLMachines.Machine {
                 fileURLWithPath: "\(FileManager().currentDirectoryPath)/\(name).machine", isDirectory: true
             ),
             includes: [
-                .library(value: "IEEE"),
-                .include(value: "IEEE.std_logic_1164.ALL"),
-                .include(value: "IEEE.math_real.ALL")
+                .library(value: ieee),
+                .include(statement: stdLogicImport),
+                .include(statement: mathRealImport)
             ],
             externalSignals: externalVariables,
             clocks: clocks,

--- a/Sources/ModelImports/State+stateInit.swift
+++ b/Sources/ModelImports/State+stateInit.swift
@@ -54,6 +54,7 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
 import LLFSMModel
 import VHDLMachines
 import VHDLParsing

--- a/Sources/VHDLMachines/Machine.swift
+++ b/Sources/VHDLMachines/Machine.swift
@@ -157,8 +157,8 @@ public struct Machine: Codable, Equatable, Hashable {
             let nameComponent = path.lastPathComponent.components(separatedBy: ".machine").first,
             let name = VariableName(rawValue: nameComponent),
             let ieee = VariableName(rawValue: "IEEE"),
-            let stdLogicImport = UseStatement(rawValue: "IEEE.std_logic_1164.all"),
-            let mathRealImport = UseStatement(rawValue: "IEEE.math_real.all")
+            let stdLogicImport = UseStatement(rawValue: "use IEEE.std_logic_1164.all;"),
+            let mathRealImport = UseStatement(rawValue: "use IEEE.math_real.all;")
         else {
             return nil
         }

--- a/Sources/VHDLMachines/Machine.swift
+++ b/Sources/VHDLMachines/Machine.swift
@@ -144,6 +144,8 @@ public struct Machine: Codable, Equatable, Hashable {
         self.architectureBody = architectureBody
     }
 
+    // swiftlint:disable function_body_length
+
     /// Creates an initial machine that will be located at `path`. The initial machine contains an Initial and
     /// Suspended state with the default actions (OnEntry, OnExit, Internal, OnResume, OnSuspend). This new
     /// machine is not parameterised, but does include the suspension semantics.
@@ -153,7 +155,10 @@ public struct Machine: Codable, Equatable, Hashable {
     public static func initial(path: URL) -> Machine? {
         guard
             let nameComponent = path.lastPathComponent.components(separatedBy: ".machine").first,
-            let name = VariableName(rawValue: nameComponent)
+            let name = VariableName(rawValue: nameComponent),
+            let ieee = VariableName(rawValue: "IEEE"),
+            let stdLogicImport = UseStatement(rawValue: "IEEE.std_logic_1164.all"),
+            let mathRealImport = UseStatement(rawValue: "IEEE.math_real.all")
         else {
             return nil
         }
@@ -169,9 +174,9 @@ public struct Machine: Codable, Equatable, Hashable {
             name: name,
             path: path,
             includes: [
-                .library(value: "IEEE"),
-                .include(value: "IEEE.std_logic_1164.All"),
-                .include(value: "IEEE.math_real.All")
+                .library(value: ieee),
+                .include(statement: stdLogicImport),
+                .include(statement: mathRealImport)
             ],
             externalSignals: [],
             clocks: [Clock(name: VariableName.clk, frequency: 50, unit: .MHz)],
@@ -200,5 +205,7 @@ public struct Machine: Codable, Equatable, Hashable {
             suspendedState: 1
         )
     }
+
+    // swiftlint:enable function_body_length
 
 }

--- a/Sources/VHDLMachines/VHDLCompiler.swift
+++ b/Sources/VHDLMachines/VHDLCompiler.swift
@@ -46,7 +46,7 @@ public struct VHDLCompiler {
     /// Generate the VHDL source code for a machine.
     /// - Parameter machine: The machine to compile.
     /// - Returns: The VHDL source code.
-    @usableFromInline
+    @inlinable
     func generateVHDLFile(_ machine: Machine) -> String? {
         guard let representation = MachineRepresentation(machine: machine) else {
             return nil

--- a/Sources/VHDLMachines/codeStructure/AfterStatement.swift
+++ b/Sources/VHDLMachines/codeStructure/AfterStatement.swift
@@ -54,6 +54,7 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
 import VHDLParsing
 
 /// An after statement found commonly on `LLFSM` transitions. The after statements represents a boolean
@@ -213,7 +214,8 @@ public struct AfterStatement: RawRepresentable, Equatable, Hashable, Codable, Se
             case .comparison(let expression) = conditional,
             case .greaterThanOrEqual(let lhs, let rhs) = expression,
             case .reference(let ref) = lhs,
-            case .variable(let name) = ref,
+            case .variable(let directRef) = ref,
+            case .variable(let name) = directRef,
             name == .ringletCounter,
             case .cast(let castOperation) = rhs,
             case .integer(let castExpression) = castOperation,
@@ -235,7 +237,8 @@ public struct AfterStatement: RawRepresentable, Equatable, Hashable, Codable, Se
             case .cast(let realCast) = lhs,
             case .real(let realExpression) = realCast,
             case .reference(let ref) = rhs,
-            case .variable(let name) = ref,
+            case .variable(let directRef) = ref,
+            case .variable(let name) = directRef,
             let period = Period(rawValue: name)
         else {
             return nil

--- a/Sources/VHDLMachines/codeStructure/AfterStatement.swift
+++ b/Sources/VHDLMachines/codeStructure/AfterStatement.swift
@@ -140,7 +140,7 @@ public struct AfterStatement: RawRepresentable, Equatable, Hashable, Codable, Se
         /// Create a new period from the `after` command.
         /// - Parameter after: The `after` command, e.g. `after`, `after_ps`, `after_ns`, `after_us`,
         /// `after_ms`, `after_rt`.
-        @usableFromInline
+        @inlinable
         init?(after: String) {
             guard after.lowercased().hasPrefix("after"), after.count >= 5 else {
                 return nil

--- a/Sources/VHDLMachines/codeStructure/ArchitectureHead+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/ArchitectureHead+machineInit.swift
@@ -64,7 +64,7 @@ extension ArchitectureHead {
 
     /// Create an architecture head for a machine.
     /// - Parameter machine: The machine to create the head for.
-    @usableFromInline
+    @inlinable
     init?(machine: Machine) {
         var actionNames = machine.actions
         if !machine.isSuspensible {

--- a/Sources/VHDLMachines/codeStructure/ArchitectureHead+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/ArchitectureHead+machineInit.swift
@@ -102,7 +102,7 @@ extension ArchitectureHead {
                 lower: .literal(value: .integer(value: 0))
             ))),
             name: .internalState,
-            defaultValue: .reference(variable: .variable(name: .readSnapshot)),
+            defaultValue: .reference(variable: .variable(reference: .variable(name: .readSnapshot))),
             comment: nil
         )
         let stateRepresentation = machine.states.enumerated()

--- a/Sources/VHDLMachines/codeStructure/AsynchronousBlock+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/AsynchronousBlock+machineInit.swift
@@ -62,7 +62,6 @@ extension AsynchronousBlock {
     /// Create the top-level asynchronous block that will represent the entire architecture body of a machine.
     /// This block represents all of the logic of the machine.
     /// - Parameter machine: The machine to generate the block from.
-    @usableFromInline
     init?(machine: Machine) {
         guard
             machine.drivingClock >= 0,
@@ -87,6 +86,12 @@ extension AsynchronousBlock {
         ])
     }
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - block: The block containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(block: AsynchronousBlock, replacing variable: VariableName, with value: VariableName) {
         switch block {
         case .blocks(let blocks):
@@ -130,8 +135,15 @@ extension AsynchronousBlock {
 
 }
 
+/// Add replace init.
 extension ProcessBlock {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - process: The process containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(process: ProcessBlock, replacing variable: VariableName, with value: VariableName) {
         guard let newCode = SynchronousBlock(block: process.code, replacing: variable, with: value) else {
             return nil
@@ -142,8 +154,15 @@ extension ProcessBlock {
 
 }
 
+/// Add replace init.
 extension ComponentInstantiation {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - component: The component containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(component: ComponentInstantiation, replacing variable: VariableName, with value: VariableName) {
         let generic: GenericMap?
         if let gen = component.generic {
@@ -162,8 +181,15 @@ extension ComponentInstantiation {
 
 }
 
+/// Add replace init.
 extension PortMap {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - map: The map containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(map: PortMap, replacing variable: VariableName, with value: VariableName) {
         let newVariables = map.variables.compactMap {
             VariableMap(map: $0, replacing: variable, with: value)
@@ -176,8 +202,15 @@ extension PortMap {
 
 }
 
+/// Add replace init.
 extension VariableMap {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - map: The map containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(map: VariableMap, replacing variable: VariableName, with value: VariableName) {
         guard let newRhs = VariableAssignment(assignment: map.rhs, replacing: variable, with: value) else {
             return nil
@@ -187,8 +220,15 @@ extension VariableMap {
 
 }
 
+/// Add replace init.
 extension VariableAssignment {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - assignment: The assignment containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(assignment: VariableAssignment, replacing variable: VariableName, with value: VariableName) {
         switch assignment {
         case .reference(let ref):
@@ -203,8 +243,15 @@ extension VariableAssignment {
 
 }
 
+/// Add replace init.
 extension GenericMap {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - map: The map containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(map: GenericMap, replacing variable: VariableName, with value: VariableName) {
         let newVariables = map.variables.compactMap {
             GenericVariableMap(map: $0, replacing: variable, with: value)
@@ -217,8 +264,15 @@ extension GenericMap {
 
 }
 
+/// Add replace init.
 extension GenericVariableMap {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - map: The map containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(map: GenericVariableMap, replacing variable: VariableName, with value: VariableName) {
         guard let newRhs = Expression(expression: map.rhs, replacing: variable, with: value) else {
             return nil

--- a/Sources/VHDLMachines/codeStructure/AsynchronousBlock+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/AsynchronousBlock+machineInit.swift
@@ -110,10 +110,21 @@ extension AsynchronousBlock {
             }
             self = .process(block: newProcess)
         case .statement(let statement):
-            guard let newStatement = Statement(statement: statement, replacing: variable, with: value) else {
+            guard
+                let newStatement = AsynchronousStatement(
+                    statement: statement, replacing: variable, with: value
+                )
+            else {
                 return nil
             }
             self = .statement(statement: newStatement)
+        case .function(let function):
+            guard
+                let newFunction = FunctionImplementation(function: function, replacing: variable, with: value)
+            else {
+                return nil
+            }
+            self = .function(block: newFunction)
         }
     }
 

--- a/Sources/VHDLMachines/codeStructure/CaseStatement+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/CaseStatement+machineInit.swift
@@ -78,7 +78,8 @@ extension CaseStatement {
             return nil
         }
         self.init(
-            condition: .reference(variable: .variable(name: .internalState)), cases: cases + [.othersNull]
+            condition: .reference(variable: .variable(reference: .variable(name: .internalState))),
+            cases: cases + [.othersNull]
         )
     }
 

--- a/Sources/VHDLMachines/codeStructure/ConstantSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/ConstantSignal+constants.swift
@@ -64,7 +64,7 @@ extension ConstantSignal {
     // swiftlint:disable force_unwrapping
 
     /// The suspension commands.
-    static let commands = [
+    @usableFromInline static let commands = [
         ConstantSignal(
             name: .nullCommand,
             type: .ranged(type: .stdLogicVector(size: .downto(
@@ -100,7 +100,7 @@ extension ConstantSignal {
     ]
 
     /// The ringlet constants.
-    static let ringletConstants: [ConstantSignal] = [
+    @usableFromInline static let ringletConstants: [ConstantSignal] = [
         ConstantSignal(
             name: .ringletLength,
             type: .real,
@@ -158,7 +158,7 @@ extension ConstantSignal {
     ///   - state: The state to convert.
     ///   - bitsRequired: The bits required for all the states to be covered.
     ///   - index: The index of this `state` in the states array of the machine.
-    @usableFromInline
+    @inlinable
     init?(state: State, bitsRequired: Int, index: Int) {
         guard bitsRequired > 0, index >= 0 else {
             return nil
@@ -183,7 +183,7 @@ extension ConstantSignal {
     /// - Returns: The constant declaration for the state actions.
     /// - Note: This method also includes the reserved actions `NoOnEntry`, `CheckTransition`, `ReadSnapshot`
     /// and `WriteSnapshot`.
-    @usableFromInline
+    @inlinable
     static func constants(for actions: [VariableName]) -> [ConstantSignal]? {
         let actionNamesArray = [
             .noOnEntry, .checkTransition, VariableName.readSnapshot, .writeSnapshot
@@ -221,7 +221,7 @@ extension ConstantSignal {
     /// Create a constant `VHDL` literal that represents a clocks period as a `real` value in picoseconds.
     /// - Parameter period: The period to convert.
     /// - Returns: The constant signal.
-    @usableFromInline
+    @inlinable
     static func clockPeriod(period: Time) -> ConstantSignal? {
         guard
             let comment = Comment(rawValue: "-- ps"),

--- a/Sources/VHDLMachines/codeStructure/ConstantSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/ConstantSignal+constants.swift
@@ -106,7 +106,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .multiplication(
                 lhs: .literal(value: .decimal(value: 5.0)),
-                rhs: .reference(variable: .variable(name: .clockPeriod))
+                rhs: .reference(variable: .variable(reference: .variable(name: .clockPeriod)))
             ))
         )!,
         ConstantSignal(
@@ -114,7 +114,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .division(
                 lhs: .literal(value: .decimal(value: 1.0)),
-                rhs: .reference(variable: .variable(name: .ringletLength))
+                rhs: .reference(variable: .variable(reference: .variable(name: .ringletLength)))
             ))
         )!,
         ConstantSignal(
@@ -122,7 +122,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .multiplication(
                 lhs: .literal(value: .decimal(value: 1000.0)),
-                rhs: .reference(variable: .variable(name: .ringletPerPs))
+                rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
             ))
         )!,
         ConstantSignal(
@@ -130,7 +130,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .multiplication(
                 lhs: .literal(value: .decimal(value: 1_000_000.0)),
-                rhs: .reference(variable: .variable(name: .ringletPerPs))
+                rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
             ))
         )!,
         ConstantSignal(
@@ -138,7 +138,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .multiplication(
                 lhs: .literal(value: .decimal(value: 1_000_000_000.0)),
-                rhs: .reference(variable: .variable(name: .ringletPerPs))
+                rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
             ))
         )!,
         ConstantSignal(
@@ -146,7 +146,7 @@ extension ConstantSignal {
             type: .real,
             value: .binary(operation: .multiplication(
                 lhs: .literal(value: .decimal(value: 1_000_000_000_000.0)),
-                rhs: .reference(variable: .variable(name: .ringletPerPs))
+                rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
             ))
         )!
     ]

--- a/Sources/VHDLMachines/codeStructure/Entity+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/Entity+machineInit.swift
@@ -61,7 +61,7 @@ extension Entity {
 
     /// Create the entity declaration for a machine.
     /// - Parameter machine: The machine to convert.
-    @usableFromInline
+    @inlinable
     init?(machine: Machine) {
         let clocks = machine.clocks.map { PortSignal(clock: $0) }
         var signals: [PortSignal] = clocks + machine.externalSignals.map {

--- a/Sources/VHDLMachines/codeStructure/Expression+Inits.swift
+++ b/Sources/VHDLMachines/codeStructure/Expression+Inits.swift
@@ -103,7 +103,7 @@ extension Expression {
         case .precedence(let condition):
             self = .precedence(value: Expression(condition: condition))
         case .variable(let name):
-            self = .reference(variable: .variable(name: name))
+            self = .reference(variable: .variable(reference: .variable(name: name)))
         }
     }
 
@@ -120,12 +120,13 @@ extension Expression {
         } else {
             calculation = .binary(
                 operation: .multiplication(
-                    lhs: castedAmount, rhs: .reference(variable: .variable(name: period.rawValue))
+                    lhs: castedAmount,
+                    rhs: .reference(variable: .variable(reference: .variable(name: period.rawValue)))
                 )
             )
         }
         self = .precedence(value: .conditional(condition: .comparison(value: .greaterThanOrEqual(
-            lhs: .reference(variable: .variable(name: .ringletCounter)),
+            lhs: .reference(variable: .variable(reference: .variable(name: .ringletCounter))),
             rhs: .cast(operation: .integer(
                 expression: .functionCall(call: .mathReal(function: .ceil(expression: calculation)))
             ))

--- a/Sources/VHDLMachines/codeStructure/LocalSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/LocalSignal+constants.swift
@@ -70,7 +70,7 @@ extension LocalSignal {
         )
         let stateType = SignalType.ranged(type: .stdLogicVector(size: range))
         let initialState = Expression.reference(
-            variable: .variable(name: VariableName.name(for: states[machine.initialState]))
+            variable: .variable(reference: .variable(name: .name(for: states[machine.initialState])))
         )
         guard let size = range.size else {
             return nil
@@ -110,7 +110,7 @@ extension LocalSignal {
             ]
         }
         let suspendedState = Expression.reference(
-            variable: .variable(name: VariableName.name(for: states[suspendedStateIndex]))
+            variable: .variable(reference: .variable(name: .name(for: states[suspendedStateIndex])))
         )
         let defaultState = machine.isParameterised ? suspendedState : initialState
         return [

--- a/Sources/VHDLMachines/codeStructure/LocalSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/LocalSignal+constants.swift
@@ -11,7 +11,7 @@ import VHDLParsing
 extension LocalSignal {
 
     /// The ringlet counter variable.
-    static let ringletCounter = LocalSignal(
+    @usableFromInline static let ringletCounter = LocalSignal(
         type: .natural,
         name: .ringletCounter,
         defaultValue: .literal(value: .integer(value: 0)),
@@ -29,21 +29,21 @@ extension LocalSignal {
 
     /// Create a local snapshot for an external variable.
     /// - Parameter signal: The signal to convert into a snapshot.
-    @usableFromInline
+    @inlinable
     init(snapshot signal: PortSignal) {
         self.init(type: signal.type, name: signal.name, defaultValue: nil, comment: nil)
     }
 
     /// Create a local snapshot for a parameter.
     /// - Parameter parameter: The parameter to convert into a snapshot.
-    @usableFromInline
+    @inlinable
     init(snapshot parameter: Parameter) {
         self.init(type: parameter.type, name: parameter.name, defaultValue: nil, comment: nil)
     }
 
     /// Create a local snapshot for an output parameter.
     /// - Parameter output: The output parameter to convert into a snapshot.
-    @usableFromInline
+    @inlinable
     init(snapshot output: ReturnableVariable) {
         self.init(type: output.type, name: output.name, defaultValue: nil, comment: nil)
     }
@@ -53,7 +53,7 @@ extension LocalSignal {
     /// Create the signals that track the internal states of the machine.
     /// - Parameter machine: The machine to create the trackers for.
     /// - Returns: The signals that track which state is executing.
-    @usableFromInline
+    @inlinable
     static func stateTrackers(machine: Machine) -> [LocalSignal]? {
         let states = machine.states
         guard

--- a/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
+++ b/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
@@ -85,7 +85,6 @@ public struct MachineRepresentation: MachineVHDLRepresentable {
 
     /// Create the machine representation for the given machine.
     /// - Parameter machine: The machine to convert into a `VHDL` file.
-    @inlinable
     public init?(machine: Machine) {
         let representationVariables: [VariableName] = [
             .suspended, .internalState, .currentState, .previousRinglet, .suspendedFrom, .ringletLength,

--- a/Sources/VHDLMachines/codeStructure/PortSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/PortSignal+constants.swift
@@ -24,14 +24,16 @@ extension PortSignal {
     /// The code that updates the snapshot from the external variable.
     var read: Statement {
         Statement.assignment(
-            name: .variable(name: snapshot.name), value: .reference(variable: .variable(name: externalName))
+            name: .variable(reference: .variable(name: snapshot.name)),
+            value: .reference(variable: .variable(reference: .variable(name: externalName)))
         )
     }
 
     /// The code that updates the external variable from the snapshot.
     var write: Statement {
         Statement.assignment(
-            name: .variable(name: externalName), value: .reference(variable: .variable(name: snapshot.name))
+            name: .variable(reference: .variable(name: externalName)),
+            value: .reference(variable: .variable(reference: .variable(name: snapshot.name)))
         )
     }
 

--- a/Sources/VHDLMachines/codeStructure/PortSignal+constants.swift
+++ b/Sources/VHDLMachines/codeStructure/PortSignal+constants.swift
@@ -12,17 +12,17 @@ import VHDLParsing
 extension PortSignal {
 
     /// The external variable name for this signal.
-    var externalName: VariableName {
+    @inlinable var externalName: VariableName {
         VariableName.name(for: self)
     }
 
     /// The snapshot of this signal.
-    var snapshot: LocalSignal {
+    @inlinable var snapshot: LocalSignal {
         LocalSignal(type: type, name: name, defaultValue: nil, comment: nil)
     }
 
     /// The code that updates the snapshot from the external variable.
-    var read: Statement {
+    @inlinable var read: Statement {
         Statement.assignment(
             name: .variable(reference: .variable(name: snapshot.name)),
             value: .reference(variable: .variable(reference: .variable(name: externalName)))
@@ -30,7 +30,7 @@ extension PortSignal {
     }
 
     /// The code that updates the external variable from the snapshot.
-    var write: Statement {
+    @inlinable var write: Statement {
         Statement.assignment(
             name: .variable(reference: .variable(name: externalName)),
             value: .reference(variable: .variable(reference: .variable(name: snapshot.name)))

--- a/Sources/VHDLMachines/codeStructure/Set+Afters.swift
+++ b/Sources/VHDLMachines/codeStructure/Set+Afters.swift
@@ -58,7 +58,7 @@
 extension Set where Element == String {
 
     /// The `after` commands supported by `LLFSMs`.
-    static let afters = Set<String>(
+    @usableFromInline static let afters = Set<String>(
         ["after", "after_ps", "after_ns", "after_us", "after_ms", "after_rt"]
     )
 

--- a/Sources/VHDLMachines/codeStructure/SynchronousBlock+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/SynchronousBlock+machineInit.swift
@@ -73,7 +73,9 @@ extension SynchronousBlock {
         let clock = machine.clocks[machine.drivingClock].name
         let code = IfBlock.ifStatement(
             condition: .conditional(
-                condition: .edge(value: .rising(expression: .reference(variable: .variable(name: clock))))
+                condition: .edge(value: .rising(
+                    expression: .reference(variable: .variable(reference: .variable(name: clock)))
+                ))
             ),
             ifBlock: .caseStatement(block: caseStatement)
         )

--- a/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
@@ -100,7 +100,7 @@ extension WhenCase {
             return nil
         }
         self.init(
-            condition: .expression(expression: .reference(variable: .variable(name: .name(for: state)))),
+            condition: .expression(expression: .reference(variable: .variable(reference: .variable(name: .name(for: state))))),
             code: code
         )
     }
@@ -115,7 +115,7 @@ extension WhenCase {
             return nil
         }
         let condition = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: .name(for: state)))
+            expression: .reference(variable: .variable(reference: .variable(name: .name(for: state))))
         )
         self.init(condition: condition, code: block)
     }

--- a/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
@@ -100,7 +100,9 @@ extension WhenCase {
             return nil
         }
         self.init(
-            condition: .expression(expression: .reference(variable: .variable(reference: .variable(name: .name(for: state))))),
+            condition: .expression(expression: .reference(
+                variable: .variable(reference: .variable(name: .name(for: state)))
+            )),
             code: code
         )
     }
@@ -136,28 +138,34 @@ extension WhenCase {
                 guard isTransitioning else {
                     return WhenCase(
                         condition: .expression(
-                            expression: .reference(variable: .variable(name: .name(for: state)))
+                            expression: .reference(variable: .variable(
+                                reference: .variable(name: .name(for: state))
+                            ))
                         ),
                         code: .statement(statement: .assignment(
-                            name: .variable(name: .internalState),
-                            value: .reference(variable: .variable(name: .internal))
+                            name: .variable(reference: .variable(name: .internalState)),
+                            value: .reference(variable: .variable(reference: .variable(name: .internal)))
                         ))
                     )
                 }
                 return WhenCase(
                     condition: .expression(
-                        expression: .reference(variable: .variable(name: .name(for: state)))
+                        expression: .reference(
+                            variable: .variable(reference: .variable(name: .name(for: state)))
+                        )
                     ),
                     code: .blocks(blocks: [
                         .statement(statement: .assignment(
-                            name: .variable(name: .targetState),
+                            name: .variable(reference: .variable(name: .targetState)),
                             value: .reference(
-                                variable: .variable(name: .name(for: machine.states[transitions[0].target]))
+                                variable: .variable(reference: .variable(
+                                    name: .name(for: machine.states[transitions[0].target])
+                                ))
                             )
                         )),
                         .statement(statement: .assignment(
-                            name: .variable(name: .internalState),
-                            value: .reference(variable: .variable(name: .onExit))
+                            name: .variable(reference: .variable(name: .internalState)),
+                            value: .reference(variable: .variable(reference: .variable(name: .onExit)))
                         ))
                     ])
                 )
@@ -165,18 +173,21 @@ extension WhenCase {
             return WhenCase(state: state, transitions: transitions, machine: machine)
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .currentState)), cases: stateCases + [
+            condition: .reference(variable: .variable(reference: .variable(name: .currentState))),
+            cases: stateCases + [
                 WhenCase(
                     condition: .others,
                     code: .statement(statement: .assignment(
-                        name: .variable(name: .internalState),
-                        value: .reference(variable: .variable(name: .internal))
+                        name: .variable(reference: .variable(name: .internalState)),
+                        value: .reference(variable: .variable(reference: .variable(name: .internal)))
                     ))
                 )
             ]
         )
         self.init(
-            condition: .expression(expression: .reference(variable: .variable(name: .checkTransition))),
+            condition: .expression(expression: .reference(
+                variable: .variable(reference: .variable(name: .checkTransition))
+            )),
             code: .caseStatement(block: statement)
         )
     }
@@ -189,9 +200,12 @@ extension WhenCase {
     ///   - next: The next action.
     private init(nullCurrentAction action: VariableName, nextAction next: VariableName) {
         self.init(
-            condition: .expression(expression: .reference(variable: .variable(name: action))),
+            condition: .expression(expression: .reference(
+                variable: .variable(reference: .variable(name: action))
+            )),
             code: .statement(statement: .assignment(
-                name: .variable(name: .internalState), value: .reference(variable: .variable(name: next))
+                name: .variable(reference: .variable(name: .internalState)),
+                value: .reference(variable: .variable(reference: .variable(name: next)))
             ))
         )
     }
@@ -204,27 +218,30 @@ extension WhenCase {
                 return WhenCase(state: $0, action: .onEntry, nextAction: .checkTransition)
             }
             let condition = WhenCondition.expression(
-                expression: .reference(variable: .variable(name: .name(for: $0)))
+                expression: .reference(variable: .variable(reference: .variable(name: .name(for: $0))))
             )
             let trailer = SynchronousBlock.statement(statement: .assignment(
-                name: .variable(name: .ringletCounter), value: .literal(value: .integer(value: 0))
+                name: .variable(reference: .variable(name: .ringletCounter)),
+                value: .literal(value: .integer(value: 0))
             ))
             guard let code = $0.actions[.onEntry] else {
                 return WhenCase(condition: condition, code: trailer)
             }
             return WhenCase(condition: condition, code: .blocks(blocks: [code, trailer]))
         }
-        let condition = WhenCondition.expression(expression: .reference(variable: .variable(name: .onEntry)))
+        let condition = WhenCondition.expression(expression: .reference(
+            variable: .variable(reference: .variable(name: .onEntry))
+        ))
         let trailer = SynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .internalState),
-            value: .reference(variable: .variable(name: .checkTransition))
+            name: .variable(reference: .variable(name: .internalState)),
+            value: .reference(variable: .variable(reference: .variable(name: .checkTransition)))
         ))
         guard !stateCases.isEmpty else {
             self.init(condition: condition, code: trailer)
             return
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .currentState)),
+            condition: .reference(variable: .variable(reference: .variable(name: .currentState))),
             cases: stateCases + [WhenCase.othersNull]
         )
         self.init(condition: condition, code: .blocks(blocks: [.caseStatement(block: statement), trailer]))
@@ -238,7 +255,7 @@ extension WhenCase {
         }
         let stateCases = machine.states.compactMap { state -> WhenCase? in
             let condition = WhenCondition.expression(
-                expression: .reference(variable: .variable(name: .name(for: state)))
+                expression: .reference(variable: .variable(reference: .variable(name: .name(for: state))))
             )
             var code: [SynchronousBlock] = []
             if let onResume = state.actions[.onResume] {
@@ -254,24 +271,27 @@ extension WhenCase {
                 return WhenCase(condition: condition, code: .blocks(blocks: code))
             }
             let trailer = SynchronousBlock.statement(statement: .assignment(
-                name: .variable(name: .ringletCounter), value: .literal(value: .integer(value: 0))
+                name: .variable(reference: .variable(name: .ringletCounter)),
+                value: .literal(value: .integer(value: 0))
             ))
             guard !code.isEmpty else {
                 return WhenCase(condition: condition, code: trailer)
             }
             return WhenCase(condition: condition, code: .blocks(blocks: code + [trailer]))
         }
-        let condition = WhenCondition.expression(expression: .reference(variable: .variable(name: .onResume)))
+        let condition = WhenCondition.expression(expression: .reference(
+            variable: .variable(reference: .variable(name: .onResume))
+        ))
         let trailer = SynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .internalState),
-            value: .reference(variable: .variable(name: .checkTransition))
+            name: .variable(reference: .variable(name: .internalState)),
+            value: .reference(variable: .variable(reference: .variable(name: .checkTransition)))
         ))
         guard !stateCases.isEmpty else {
             self.init(condition: condition, code: trailer)
             return
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .currentState)),
+            condition: .reference(variable: .variable(reference: .variable(name: .currentState))),
             cases: stateCases + [WhenCase.othersNull]
         )
         self.init(condition: condition, code: .blocks(blocks: [.caseStatement(block: statement), trailer]))
@@ -289,12 +309,14 @@ extension WhenCase {
                 return nil
             }
             return WhenCase(
-                condition: .expression(expression: .reference(variable: .variable(name: .name(for: $0)))),
+                condition: .expression(expression: .reference(
+                    variable: .variable(reference: .variable(name: .name(for: $0)))
+                )),
                 code: onSuspend
             )
         }
         let condition = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: .onSuspend))
+            expression: .reference(variable: .variable(reference: .variable(name: .onSuspend)))
         )
         var trailer: [SynchronousBlock] = []
         if let onEntry = suspendedState.actions[.onEntry] {
@@ -302,8 +324,8 @@ extension WhenCase {
         }
         trailer += [
             .statement(statement: .assignment(
-                name: .variable(name: .internalState),
-                value: .reference(variable: .variable(name: .checkTransition))
+                name: .variable(reference: .variable(name: .internalState)),
+                value: .reference(variable: .variable(reference: .variable(name: .checkTransition)))
             ))
         ]
         guard !stateCases.isEmpty else {
@@ -311,7 +333,7 @@ extension WhenCase {
             return
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .suspendedFrom)),
+            condition: .reference(variable: .variable(reference: .variable(name: .suspendedFrom))),
             cases: stateCases + [.othersNull]
         )
         self.init(condition: condition, code: .blocks(blocks: [
@@ -328,12 +350,12 @@ extension WhenCase {
                 return WhenCase(state: $0, action: .internal, nextAction: .writeSnapshot)
             }
             let condition = WhenCondition.expression(
-                expression: .reference(variable: .variable(name: .name(for: $0)))
+                expression: .reference(variable: .variable(reference: .variable(name: .name(for: $0))))
             )
             let trailer = SynchronousBlock.statement(statement: .assignment(
-                name: .variable(name: .ringletCounter),
+                name: .variable(reference: .variable(name: .ringletCounter)),
                 value: .binary(operation: .addition(
-                    lhs: .reference(variable: .variable(name: .ringletCounter)),
+                    lhs: .reference(variable: .variable(reference: .variable(name: .ringletCounter))),
                     rhs: .literal(value: .integer(value: 1))
                 ))
             ))
@@ -342,17 +364,19 @@ extension WhenCase {
             }
             return WhenCase(condition: condition, code: .blocks(blocks: [code, trailer]))
         }
-        let condition = WhenCondition.expression(expression: .reference(variable: .variable(name: .internal)))
+        let condition = WhenCondition.expression(expression: .reference(
+            variable: .variable(reference: .variable(name: .internal))
+        ))
         let trailer = SynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .internalState),
-            value: .reference(variable: .variable(name: .writeSnapshot))
+            name: .variable(reference: .variable(name: .internalState)),
+            value: .reference(variable: .variable(reference: .variable(name: .writeSnapshot)))
         ))
         guard !stateCases.isEmpty else {
             self.init(condition: condition, code: trailer)
             return
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .currentState)),
+            condition: .reference(variable: .variable(reference: .variable(name: .currentState))),
             cases: stateCases + [WhenCase.othersNull]
         )
         self.init(condition: condition, code: .blocks(blocks: [.caseStatement(block: statement), trailer]))
@@ -368,17 +392,18 @@ extension WhenCase {
             WhenCase(state: $0, action: normalAction, nextAction: nextAction)
         }
         let condition = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: normalAction))
+            expression: .reference(variable: .variable(reference: .variable(name: normalAction)))
         )
         let trailer = SynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .internalState), value: .reference(variable: .variable(name: nextAction))
+            name: .variable(reference: .variable(name: .internalState)),
+            value: .reference(variable: .variable(reference: .variable(name: nextAction)))
         ))
         guard !stateCases.isEmpty else {
             self.init(condition: condition, code: trailer)
             return
         }
         let statement = CaseStatement(
-            condition: .reference(variable: .variable(name: .currentState)),
+            condition: .reference(variable: .variable(reference: .variable(name: .currentState))),
             cases: stateCases + [WhenCase.othersNull]
         )
         self.init(condition: condition, code: .blocks(blocks: [.caseStatement(block: statement), trailer]))
@@ -393,14 +418,14 @@ extension WhenCase {
             return nil
         }
         let whenCondition = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: .readSnapshot))
+            expression: .reference(variable: .variable(reference: .variable(name: .readSnapshot)))
         )
         let initialState = machine.states[machine.initialState]
         let snapshots = machine.externalSignals.filter { $0.mode != .output }.map {
             SynchronousBlock.statement(
                 statement: .assignment(
-                    name: .variable(name: $0.name),
-                    value: .reference(variable: .variable(name: .name(for: $0)))
+                    name: .variable(reference: .variable(name: $0.name)),
+                    value: .reference(variable: .variable(reference: .variable(name: .name(for: $0))))
                 )
             )
         }
@@ -408,16 +433,17 @@ extension WhenCase {
         let onEntryBlock = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(
                 value: .notEquals(
-                    lhs: .reference(variable: .variable(name: .previousRinglet)),
-                    rhs: .reference(variable: .variable(name: .currentState))
+                    lhs: .reference(variable: .variable(reference: .variable(name: .previousRinglet))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .currentState)))
                 )
             )),
             ifBlock: .statement(statement: .assignment(
-                name: .variable(name: .internalState), value: .reference(variable: .variable(name: .onEntry))
+                name: .variable(reference: .variable(name: .internalState)),
+                value: .reference(variable: .variable(reference: .variable(name: .onEntry)))
             )),
             elseBlock: .statement(statement: .assignment(
-                name: .variable(name: .internalState),
-                value: .reference(variable: .variable(name: .noOnEntry))
+                name: .variable(reference: .variable(name: .internalState)),
+                value: .reference(variable: .variable(reference: .variable(name: .noOnEntry)))
             ))
         )
         guard
@@ -437,15 +463,15 @@ extension WhenCase {
         if machine.isParameterised {
             let parameterSnapshots = machine.parameterSignals.map {
                 SynchronousBlock.statement(statement: .assignment(
-                    name: .variable(name: $0.name),
-                    value: .reference(variable: .variable(name: .name(for: $0)))
+                    name: .variable(reference: .variable(name: $0.name)),
+                    value: .reference(variable: .variable(reference: .variable(name: .name(for: $0))))
                 ))
             }
             blocks.append(SynchronousBlock.ifStatement(block: .ifStatement(
                 // Perform snapshot of parameters on restart command.
                 condition: .conditional(condition: .comparison(value: .equality(
-                    lhs: .reference(variable: .variable(name: .command)),
-                    rhs: .reference(variable: .variable(name: .restartCommand))
+                    lhs: .reference(variable: .variable(reference: .variable(name: .command))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .restartCommand)))
                 ))),
                 ifBlock: .blocks(blocks: parameterSnapshots)
             )))
@@ -457,53 +483,74 @@ extension WhenCase {
                     // Restart semantics.
                     condition: .logical(operation: .and(
                         lhs: .precedence(value: .conditional(condition: .comparison(value: .equality(
-                            lhs: .reference(variable: .variable(name: .command)),
-                            rhs: .reference(variable: .variable(name: .restartCommand))
+                            lhs: .reference(variable: .variable(reference: .variable(name: .command))),
+                            rhs: .reference(variable: .variable(reference: .variable(name: .restartCommand)))
                         )))),
                         rhs: .precedence(value: .conditional(condition: .comparison(value: .notEquals(
-                            lhs: .reference(variable: .variable(name: .currentState)),
-                            rhs: .reference(variable: .variable(name: .name(for: initialState)))
+                            lhs: .reference(variable: .variable(reference: .variable(name: .currentState))),
+                            rhs: .reference(
+                                variable: .variable(reference: .variable(name: .name(for: initialState)))
+                            )
                         ))))
                     )),
                     ifBlock: .blocks(blocks: [
                         // Set current state to the initial state.
                         .statement(statement: .assignment(
-                            name: .variable(name: .currentState),
-                            value: .reference(variable: .variable(name: .name(for: initialState)))
+                            name: .variable(reference: .variable(name: .currentState)),
+                            value: .reference(
+                                variable: .variable(reference: .variable(name: .name(for: initialState)))
+                            )
                         )),
                         .statement(statement: .assignment(
-                            name: .variable(name: .suspended), value: .literal(value: .bit(value: .low))
+                            name: .variable(reference: .variable(name: .suspended)),
+                            value: .literal(value: .bit(value: .low))
                         )),
                         .statement(statement: .assignment(
-                            name: .variable(name: .suspendedFrom),
-                            value: .reference(variable: .variable(name: .name(for: initialState)))
+                            name: .variable(reference: .variable(name: .suspendedFrom)),
+                            value: .reference(
+                                variable: .variable(reference: .variable(name: .name(for: initialState)))
+                            )
                         )),
                         .statement(statement: .assignment(
-                            name: .variable(name: .targetState),
-                            value: .reference(variable: .variable(name: .name(for: initialState)))
+                            name: .variable(reference: .variable(name: .targetState)),
+                            value: .reference(
+                                variable: .variable(reference: .variable(name: .name(for: initialState)))
+                            )
                         )),
                         // If previously suspended perform OnResume, else perform OnEntry.
                         .ifStatement(block: .ifElse(
                             condition: .conditional(condition: .comparison(value: .equality(
-                                lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                lhs: .reference(
+                                    variable: .variable(reference: .variable(name: .previousRinglet))
+                                ),
+                                rhs: .reference(variable: .variable(
+                                    reference: .variable(name: .name(for: suspendedState))
+                                ))
                             ))),
                             ifBlock: .statement(statement: .assignment(
-                                name: .variable(name: .internalState),
-                                value: .reference(variable: .variable(name: .onResume))
+                                name: .variable(reference: .variable(name: .internalState)),
+                                value: .reference(variable: .variable(reference: .variable(name: .onResume)))
                             )),
                             elseBlock: .ifStatement(block: .ifElse(
                                 condition: .conditional(condition: .comparison(value: .equality(
-                                    lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                    rhs: .reference(variable: .variable(name: .name(for: initialState)))
+                                    lhs: .reference(variable: .variable(
+                                        reference: .variable(name: .previousRinglet)
+                                    )),
+                                    rhs: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: initialState))
+                                    ))
                                 ))),
                                 ifBlock: .statement(statement: .assignment(
-                                    name: .variable(name: .internalState),
-                                    value: .reference(variable: .variable(name: .noOnEntry))
+                                    name: .variable(reference: .variable(name: .internalState)),
+                                    value: .reference(variable: .variable(
+                                        reference: .variable(name: .noOnEntry)
+                                    ))
                                 )),
                                 elseBlock: .statement(statement: .assignment(
-                                    name: .variable(name: .internalState),
-                                    value: .reference(variable: .variable(name: .onEntry))
+                                    name: .variable(reference: .variable(name: .internalState)),
+                                    value: .reference(
+                                        variable: .variable(reference: .variable(name: .onEntry))
+                                    )
                                 ))
                             ))
                         ))
@@ -512,47 +559,69 @@ extension WhenCase {
                         // Resume semantics.
                         condition: .logical(operation: .and(
                             lhs: .precedence(value: .conditional(condition: .comparison(value: .equality(
-                                lhs: .reference(variable: .variable(name: .command)),
-                                rhs: .reference(variable: .variable(name: .resumeCommand))
+                                lhs: .reference(variable: .variable(reference: .variable(name: .command))),
+                                rhs: .reference(
+                                    variable: .variable(reference: .variable(name: .resumeCommand))
+                                )
                             )))),
                             rhs: .precedence(value: .logical(operation: .and(
                                 lhs: .precedence(value: .conditional(condition: .comparison(value: .equality(
-                                    lhs: .reference(variable: .variable(name: .currentState)),
-                                    rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .currentState))
+                                    ),
+                                    rhs: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 )))),
                                 rhs: .precedence(value: .conditional(condition: .comparison(value: .notEquals(
-                                    lhs: .reference(variable: .variable(name: .suspendedFrom)),
-                                    rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .suspendedFrom))
+                                    ),
+                                    rhs: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 ))))
                             )))
                         )),
                         // Set current state to the state the machine was suspended from.
                         ifBlock: .blocks(blocks: [
                             .statement(statement: .assignment(
-                                name: .variable(name: .suspended),
+                                name: .variable(reference: .variable(name: .suspended)),
                                 value: .literal(value: .bit(value: .low))
                             )),
                             .statement(statement: .assignment(
-                                name: .variable(name: .currentState),
-                                value: .reference(variable: .variable(name: .suspendedFrom))
+                                name: .variable(reference: .variable(name: .currentState)),
+                                value: .reference(
+                                    variable: .variable(reference: .variable(name: .suspendedFrom))
+                                )
                             )),
                             .statement(statement: .assignment(
-                                name: .variable(name: .targetState),
-                                value: .reference(variable: .variable(name: .suspendedFrom))
+                                name: .variable(reference: .variable(name: .targetState)),
+                                value: .reference(
+                                    variable: .variable(reference: .variable(name: .suspendedFrom))
+                                )
                             )),
                             // If previous state was suspended perform OnResume, else perform NoOnEntry.
                             .ifStatement(block: .ifElse(
                                 condition: .conditional(condition: .comparison(value: .equality(
-                                    lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                    rhs: .reference(variable: .variable(name: .suspendedFrom))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .previousRinglet))
+                                    ),
+                                    rhs: .reference(
+                                        variable: .variable(reference: .variable(name: .suspendedFrom))
+                                    )
                                 ))),
                                 ifBlock: .statement(statement: .assignment(
-                                    name: .variable(name: .internalState),
-                                    value: .reference(variable: .variable(name: .noOnEntry))
+                                    name: .variable(reference: .variable(name: .internalState)),
+                                    value: .reference(
+                                        variable: .variable(reference: .variable(name: .noOnEntry))
+                                    )
                                 )),
                                 elseBlock: .statement(statement: .assignment(
-                                    name: .variable(name: .internalState),
-                                    value: .reference(variable: .variable(name: .onResume))
+                                    name: .variable(reference: .variable(name: .internalState)),
+                                    value: .reference(
+                                        variable: .variable(reference: .variable(name: .onResume))
+                                    )
                                 ))
                             ))
                         ]),
@@ -560,108 +629,150 @@ extension WhenCase {
                             // Suspend semantics.
                             condition: .logical(operation: .and(
                                 lhs: .precedence(value: .conditional(condition: .comparison(value: .equality(
-                                    lhs: .reference(variable: .variable(name: .command)),
-                                    rhs: .reference(variable: .variable(name: .suspendCommand))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .command))
+                                    ),
+                                    rhs: .reference(
+                                        variable: .variable(reference: .variable(name: .suspendCommand))
+                                    )
                                 )))),
                                 rhs: .precedence(value: .conditional(condition: .comparison(value: .notEquals(
-                                    lhs: .reference(variable: .variable(name: .currentState)),
-                                    rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .currentState))
+                                    ),
+                                    rhs: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 ))))
                             )),
                             ifBlock: .blocks(blocks: [
                                 // Set current state to the suspended state.
                                 .statement(statement: .assignment(
-                                    name: .variable(name: .suspendedFrom),
-                                    value: .reference(variable: .variable(name: .currentState))
+                                    name: .variable(reference: .variable(name: .suspendedFrom)),
+                                    value: .reference(
+                                        variable: .variable(reference: .variable(name: .currentState))
+                                    )
                                 )),
                                 .statement(statement: .assignment(
-                                    name: .variable(name: .suspended),
+                                    name: .variable(reference: .variable(name: .suspended)),
                                     value: .literal(value: .bit(value: .high))
                                 )),
                                 .statement(statement: .assignment(
-                                    name: .variable(name: .currentState),
-                                    value: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    name: .variable(reference: .variable(name: .currentState)),
+                                    value: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 )),
                                 .statement(statement: .assignment(
-                                    name: .variable(name: .targetState),
-                                    value: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    name: .variable(reference: .variable(name: .targetState)),
+                                    value: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 )),
                                 // Perform OnSuspend if not in the suspended state previously.
                                 .ifStatement(block: .ifElse(
                                     condition: .conditional(condition: .comparison(value: .equality(
-                                        lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                        rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                        lhs: .reference(variable: .variable(
+                                            reference: .variable(name: .previousRinglet)
+                                        )),
+                                        rhs: .reference(variable: .variable(
+                                            reference: .variable(name: .name(for: suspendedState))
+                                        ))
                                     ))),
                                     ifBlock: .statement(statement: .assignment(
-                                        name: .variable(name: .internalState),
-                                        value: .reference(variable: .variable(name: .noOnEntry))
+                                        name: .variable(reference: .variable(name: .internalState)),
+                                        value: .reference(
+                                            variable: .variable(reference: .variable(name: .noOnEntry))
+                                        )
                                     )),
                                     elseBlock: .statement(statement: .assignment(
-                                        name: .variable(name: .internalState),
-                                        value: .reference(variable: .variable(name: .onSuspend))
+                                        name: .variable(reference: .variable(name: .internalState)),
+                                        value: .reference(
+                                            variable: .variable(reference: .variable(name: .onSuspend))
+                                        )
                                     ))
                                 ))
                             ]),
                             // Suspended state execution.
                             elseBlock: .ifStatement(block: .ifElse(
                                 condition: .conditional(condition: .comparison(value: .equality(
-                                    lhs: .reference(variable: .variable(name: .currentState)),
-                                    rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                    lhs: .reference(
+                                        variable: .variable(reference: .variable(name: .currentState))
+                                    ),
+                                    rhs: .reference(variable: .variable(
+                                        reference: .variable(name: .name(for: suspendedState))
+                                    ))
                                 ))),
                                 // Set suspended flag to logic high.
                                 ifBlock: .blocks(blocks: [
                                     .statement(statement: .assignment(
-                                        name: .variable(name: .suspended),
+                                        name: .variable(reference: .variable(name: .suspended)),
                                         value: .literal(value: .bit(value: .high))
                                     )),
                                     // Execute OnSuspend if not in the suspended state previously.
                                     .ifStatement(block: .ifElse(
                                         condition: .conditional(condition: .comparison(value: .notEquals(
-                                            lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                            rhs: .reference(
-                                                variable: .variable(name: .name(for: suspendedState))
-                                            )
+                                            lhs: .reference(variable: .variable(
+                                                reference: .variable(name: .previousRinglet)
+                                            )),
+                                            rhs: .reference(variable: .variable(
+                                                reference: .variable(name: .name(for: suspendedState))
+                                            ))
                                         ))),
                                         ifBlock: .statement(statement: .assignment(
-                                            name: .variable(name: .internalState),
-                                            value: .reference(variable: .variable(name: .onSuspend))
+                                            name: .variable(reference: .variable(name: .internalState)),
+                                            value: .reference(
+                                                variable: .variable(reference: .variable(name: .onSuspend))
+                                            )
                                         )),
                                         elseBlock: .statement(statement: .assignment(
-                                            name: .variable(name: .internalState),
-                                            value: .reference(variable: .variable(name: .noOnEntry))
+                                            name: .variable(reference: .variable(name: .internalState)),
+                                            value: .reference(
+                                                variable: .variable(reference: .variable(name: .noOnEntry))
+                                            )
                                         ))
                                     ))
                                 ]),
                                 // Transition from Suspended.
                                 elseBlock: .ifStatement(block: .ifElse(
                                     condition: .conditional(condition: .comparison(value: .equality(
-                                        lhs: .reference(variable: .variable(name: .previousRinglet)),
-                                        rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                                        lhs: .reference(variable: .variable(
+                                            reference: .variable(name: .previousRinglet)
+                                        )),
+                                        rhs: .reference(variable: .variable(
+                                            reference: .variable(name: .name(for: suspendedState))
+                                        ))
                                     ))),
                                     // Execute onResume.
                                     ifBlock: .blocks(blocks: [
                                         .statement(statement: .assignment(
-                                            name: .variable(name: .internalState),
-                                            value: .reference(variable: .variable(name: .onResume))
+                                            name: .variable(reference: .variable(name: .internalState)),
+                                            value: .reference(
+                                                variable: .variable(reference: .variable(name: .onResume))
+                                            )
                                         )),
                                         .statement(statement: .assignment(
-                                            name: .variable(name: .suspended),
+                                            name: .variable(reference: .variable(name: .suspended)),
                                             value: .literal(value: .bit(value: .low))
                                         )),
                                         .statement(statement: .assignment(
-                                            name: .variable(name: .suspendedFrom),
-                                            value: .reference(variable: .variable(name: .currentState))
+                                            name: .variable(reference: .variable(name: .suspendedFrom)),
+                                            value: .reference(
+                                                variable: .variable(reference: .variable(name: .currentState))
+                                            )
                                         ))
                                     ]),
                                     // Normal execution.
                                     elseBlock: .blocks(blocks: [
                                         .statement(statement: .assignment(
-                                            name: .variable(name: .suspended),
+                                            name: .variable(reference: .variable(name: .suspended)),
                                             value: .literal(value: .bit(value: .low))
                                         )),
                                         .statement(statement: .assignment(
-                                            name: .variable(name: .suspendedFrom),
-                                            value: .reference(variable: .variable(name: .currentState))
+                                            name: .variable(reference: .variable(name: .suspendedFrom)),
+                                            value: .reference(
+                                                variable: .variable(reference: .variable(name: .currentState))
+                                            )
                                         )),
                                         // Decide whether to perform OnEntry.
                                         .ifStatement(block: onEntryBlock)
@@ -676,39 +787,37 @@ extension WhenCase {
         self.init(condition: whenCondition, code: .blocks(blocks: blocks))
     }
 
-    // swiftlint:enable function_body_length
-
     /// Create the `writeSnapshot` case for a machine.
     /// - Parameter machine: The machine to create the case for.
     private init?(writeSnapshotMachine machine: Machine) {
         let snapshots = machine.externalSignals.filter { $0.mode != .input }.map {
             SynchronousBlock.statement(statement: .assignment(
-                name: .variable(name: .name(for: $0)),
-                value: .reference(variable: .variable(name: $0.name))
+                name: .variable(reference: .variable(name: .name(for: $0))),
+                value: .reference(variable: .variable(reference: .variable(name: $0.name)))
             ))
         }
         var blocks = snapshots + [
             .statement(statement: .assignment(
-                name: .variable(name: .internalState),
-                value: .reference(variable: .variable(name: .readSnapshot))
+                name: .variable(reference: .variable(name: .internalState)),
+                value: .reference(variable: .variable(reference: .variable(name: .readSnapshot)))
             )),
             .statement(statement: .assignment(
-                name: .variable(name: .previousRinglet),
-                value: .reference(variable: .variable(name: .currentState))
+                name: .variable(reference: .variable(name: .previousRinglet)),
+                value: .reference(variable: .variable(reference: .variable(name: .currentState)))
             )),
             .statement(statement: .assignment(
-                name: .variable(name: .currentState),
-                value: .reference(variable: .variable(name: .targetState))
+                name: .variable(reference: .variable(name: .currentState)),
+                value: .reference(variable: .variable(reference: .variable(name: .targetState)))
             ))
         ]
         let condition = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: .writeSnapshot))
+            expression: .reference(variable: .variable(reference: .variable(name: .writeSnapshot)))
         )
         if machine.isParameterised {
             let outputs = machine.returnableSignals.map {
                 SynchronousBlock.statement(statement: .assignment(
-                    name: .variable(name: .name(for: $0)),
-                    value: .reference(variable: .variable(name: $0.name))
+                    name: .variable(reference: .variable(name: .name(for: $0))),
+                    value: .reference(variable: .variable(reference: .variable(name: $0.name)))
                 ))
             }
             guard !outputs.isEmpty else {
@@ -722,8 +831,10 @@ extension WhenCase {
             blocks += [
                 .ifStatement(block: .ifStatement(
                     condition: .conditional(condition: .comparison(value: .equality(
-                        lhs: .reference(variable: .variable(name: .currentState)),
-                        rhs: .reference(variable: .variable(name: .name(for: suspendedState)))
+                        lhs: .reference(variable: .variable(reference: .variable(name: .currentState))),
+                        rhs: .reference(variable: .variable(
+                            reference: .variable(name: .name(for: suspendedState))
+                        ))
                     ))),
                     ifBlock: .blocks(blocks: outputs)
                 ))
@@ -731,6 +842,8 @@ extension WhenCase {
         }
         self.init(condition: condition, code: .blocks(blocks: blocks))
     }
+
+    // swiftlint:enable function_body_length
 
 }
 
@@ -767,19 +880,19 @@ private extension SynchronousBlock {
                 condition: Expression(condition: transition.condition),
                 ifBlock: .blocks(blocks: [
                     .statement(statement: .assignment(
-                        name: .variable(name: .targetState),
-                        value: .reference(
-                            variable: .variable(name: .name(for: machine.states[transition.target]))
-                        )
+                        name: .variable(reference: .variable(name: .targetState)),
+                        value: .reference(variable: .variable(
+                            reference: .variable(name: .name(for: machine.states[transition.target]))
+                        ))
                     )),
                     .statement(statement: .assignment(
-                        name: .variable(name: .internalState),
-                        value: .reference(variable: .variable(name: .onExit))
+                        name: .variable(reference: .variable(name: .internalState)),
+                        value: .reference(variable: .variable(reference: .variable(name: .onExit)))
                     ))
                 ]),
                 elseBlock: .statement(statement: .assignment(
-                    name: .variable(name: .internalState),
-                    value: .reference(variable: .variable(name: .internal))
+                    name: .variable(reference: .variable(name: .internalState)),
+                    value: .reference(variable: .variable(reference: .variable(name: .internal)))
                 ))
             ))
             return
@@ -793,14 +906,16 @@ private extension SynchronousBlock {
             condition: Expression(condition: transition.condition),
             ifBlock: .blocks(blocks: [
                 .statement(statement: .assignment(
-                    name: .variable(name: .targetState),
+                    name: .variable(reference: .variable(name: .targetState)),
                     value: .reference(
-                        variable: .variable(name: .name(for: machine.states[transition.target]))
+                        variable: .variable(reference: .variable(
+                            name: .name(for: machine.states[transition.target])
+                        ))
                     )
                 )),
                 .statement(statement: .assignment(
-                    name: .variable(name: .internalState),
-                    value: .reference(variable: .variable(name: .onExit))
+                    name: .variable(reference: .variable(name: .internalState)),
+                    value: .reference(variable: .variable(reference: .variable(name: .onExit)))
                 ))
             ]),
             elseBlock: remainingTransitions

--- a/Sources/VHDLMachines/codeStructure/replaceInits/AfterStatement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/AfterStatement+replaceInit.swift
@@ -64,7 +64,7 @@ extension AfterStatement {
     ///   - statement: The statement containing the `variable`'s to be replaced.
     ///   - variable: The variable to be replaced.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(statement: AfterStatement, replacing variable: VariableName, with value: VariableName) {
         guard let newAmount = Expression(
             expression: statement.amount, replacing: variable, with: value

--- a/Sources/VHDLMachines/codeStructure/replaceInits/AsynchronousStatement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/AsynchronousStatement+replaceInit.swift
@@ -56,8 +56,15 @@
 
 import VHDLParsing
 
+/// Add replace inits.
 extension AsynchronousStatement {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - statement: The statement containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(statement: AsynchronousStatement, replacing variable: VariableName, with value: VariableName) {
         switch statement {
         case .assignment(let name, let expression):
@@ -77,8 +84,15 @@ extension AsynchronousStatement {
 
 }
 
+/// Add replace inits.
 extension AsynchronousExpression {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - expression: The expression containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(expression: AsynchronousExpression, replacing variable: VariableName, with value: VariableName) {
         switch expression {
         case .expression(let expression):
@@ -98,8 +112,15 @@ extension AsynchronousExpression {
 
 }
 
+/// Add replace inits.
 extension WhenBlock {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - block: The block containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(block: WhenBlock, replacing variable: VariableName, with value: VariableName) {
         switch block {
         case .when(let statement):
@@ -121,8 +142,15 @@ extension WhenBlock {
 
 }
 
+/// Add replace inits.
 extension WhenStatement {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - statement: The statement containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(statement: WhenStatement, replacing variable: VariableName, with value: VariableName) {
         guard
             let newCondition = Expression(expression: statement.condition, replacing: variable, with: value),
@@ -135,8 +163,15 @@ extension WhenStatement {
 
 }
 
+/// Add replace inits.
 extension WhenElseStatement {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - statement: The statement containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(statement: WhenElseStatement, replacing variable: VariableName, with value: VariableName) {
         guard
             let newCondition = Expression(expression: statement.condition, replacing: variable, with: value),

--- a/Sources/VHDLMachines/codeStructure/replaceInits/AsynchronousStatement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/AsynchronousStatement+replaceInit.swift
@@ -61,8 +61,8 @@ extension AsynchronousStatement {
     init?(statement: AsynchronousStatement, replacing variable: VariableName, with value: VariableName) {
         switch statement {
         case .assignment(let name, let expression):
-            let newName = VariableReference(reference: name, replacing: variable, with: value)
             guard
+                let newName = VariableReference(reference: name, replacing: variable, with: value),
                 let newExpression = AsynchronousExpression(
                     expression: expression, replacing: variable, with: value
                 )

--- a/Sources/VHDLMachines/codeStructure/replaceInits/BinaryOperation+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/BinaryOperation+replaceInit.swift
@@ -64,7 +64,7 @@ extension BinaryOperation {
     ///   - operation: The operation containing the `variables`'s to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The new `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(operation: BinaryOperation, replacing variable: VariableName, with value: VariableName) {
         switch operation {
         case .addition(let lhs, let rhs):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/BooleanExpressions+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/BooleanExpressions+replaceInit.swift
@@ -66,7 +66,7 @@ extension BooleanExpression {
     ///   - expression: The expression to replace.
     ///   - variable: The variable to replace in `expression`.
     ///   - value: The new value to replace `variable` with.
-    @usableFromInline
+    @inlinable
     init?(expression: BooleanExpression, replacing variable: VariableName, with value: VariableName) {
         switch expression {
         case .and(let lhs, let rhs):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/CaseStatement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/CaseStatement+replaceInit.swift
@@ -64,7 +64,7 @@ extension CaseStatement {
     ///   - statement: The statement containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(statement: CaseStatement, replacing variable: VariableName, with value: VariableName) {
         let newCases = statement.cases.compactMap {
             WhenCase(whenCase: $0, replacing: variable, with: value)

--- a/Sources/VHDLMachines/codeStructure/replaceInits/CastOperation+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/CastOperation+replaceInit.swift
@@ -67,7 +67,7 @@ extension CastOperation {
     ///   - operation: The operation containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(operation: CastOperation, replacing variable: VariableName, with value: VariableName) {
         switch operation {
         case .bit(let expression):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/ComparisonOperation+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/ComparisonOperation+replaceInit.swift
@@ -64,7 +64,7 @@ extension ComparisonOperation {
     ///   - operation: The operation containing the `variable`'s to be replaced.
     ///   - variable: The `variable` to replace.
     ///   - value: The new `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(operation: ComparisonOperation, replacing variable: VariableName, with value: VariableName) {
         switch operation {
         case .equality(let lhs, let rhs):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/ConditionalExpression+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/ConditionalExpression+replaceInit.swift
@@ -64,7 +64,7 @@ extension ConditionalExpression {
     ///   - expression: The expression containing the `variable`'s to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(expression: ConditionalExpression, replacing variable: VariableName, with value: VariableName) {
         switch expression {
         case .comparison(let operation):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/DirectReference+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/DirectReference+replaceInit.swift
@@ -1,4 +1,4 @@
-// VariableReference+replaceInit.swift
+// DirectReference+replaceInit.swift
 // VHDLMachines
 // 
 // Created by Morgan McColl.
@@ -56,26 +56,30 @@
 
 import VHDLParsing
 
-/// Add replace initialiser.
-extension VariableReference {
+extension DirectReference {
 
-    /// Replaces a `variable` within a `VariableReference` with a new `value`.
-    /// - Parameters:
-    ///   - reference: The reference containing `variable`.
-    ///   - variable: The variable to replace in `reference`.
-    ///   - value: The new value to replace `variable` with.
-    @usableFromInline
-    init(reference: VariableReference, replacing variable: VariableName, with value: VariableName) {
+    init(reference: DirectReference, replacing variable: VariableName, with value: VariableName) {
         switch reference {
-        case .indexed(let name, let index):
+        case .member(let access):
+            self = .member(access: MemberAccess(access: access, replacing: variable, with: value))
+        case .variable(let name):
             guard name == variable else {
                 self = reference
                 return
             }
-            self = .indexed(name: value, index: index)
-        case .variable(let ref):
-            self = .variable(reference: DirectReference(reference: ref, replacing: variable, with: value))
+            self = .variable(name: value)
         }
+    }
+
+}
+
+extension MemberAccess {
+
+    init(access: MemberAccess, replacing variable: VariableName, with value: VariableName) {
+        self.init(
+            record: access.record == variable ? value : access.record,
+            member: DirectReference(reference: access.member, replacing: variable, with: value)
+        )
     }
 
 }

--- a/Sources/VHDLMachines/codeStructure/replaceInits/DirectReference+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/DirectReference+replaceInit.swift
@@ -56,8 +56,15 @@
 
 import VHDLParsing
 
+/// Add replace init.
 extension DirectReference {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - reference: The reference containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init(reference: DirectReference, replacing variable: VariableName, with value: VariableName) {
         switch reference {
         case .member(let access):
@@ -73,8 +80,15 @@ extension DirectReference {
 
 }
 
+/// Add replace init.
 extension MemberAccess {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - access: The access containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init(access: MemberAccess, replacing variable: VariableName, with value: VariableName) {
         self.init(
             record: access.record == variable ? value : access.record,

--- a/Sources/VHDLMachines/codeStructure/replaceInits/EdgeCondition+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/EdgeCondition+replaceInit.swift
@@ -64,7 +64,7 @@ extension EdgeCondition {
     ///   - condition: The condition containing the `variable` to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(condition: EdgeCondition, replacing variable: VariableName, with value: VariableName) {
         switch condition {
         case .rising(let expression):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Expression+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Expression+replaceInit.swift
@@ -64,7 +64,7 @@ extension Expression {
     ///   - expression: The expression containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(expression: Expression, replacing variable: VariableName, with value: VariableName) {
         switch expression {
         case .binary(let operation):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/ForLoop+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/ForLoop+replaceInit.swift
@@ -64,7 +64,7 @@ extension ForLoop {
     ///   - loop: The loop containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(loop: ForLoop, replacing variable: VariableName, with value: VariableName) {
         guard
             let newRange = VectorSize(size: loop.range, replacing: variable, with: value),

--- a/Sources/VHDLMachines/codeStructure/replaceInits/FunctionCall+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/FunctionCall+replaceInit.swift
@@ -64,7 +64,7 @@ extension FunctionCall {
     ///   - call: The call containing the `variable`'s to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The new `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(call: FunctionCall, replacing variable: VariableName, with value: VariableName) {
         switch call {
         case .custom(let function):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/FunctionImplementation+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/FunctionImplementation+replaceInit.swift
@@ -56,8 +56,15 @@
 
 import VHDLParsing
 
+/// Add replace init.
 extension FunctionImplementation {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - function: The function containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(function: FunctionImplementation, replacing variable: VariableName, with value: VariableName) {
         let newArguments = function.arguments.compactMap {
             ArgumentDefinition(definition: $0, replacing: variable, with: value)
@@ -79,8 +86,15 @@ extension FunctionImplementation {
 
 }
 
+/// Add replace init.
 extension ArgumentDefinition {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - definition: The definition containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(definition: ArgumentDefinition, replacing variable: VariableName, with value: VariableName) {
         guard let newType = Type(type: definition.type, replacing: variable, with: value) else {
             return nil
@@ -105,8 +119,15 @@ extension ArgumentDefinition {
 
 }
 
+/// Add replace init.
 extension Type {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - type: The type containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(type: Type, replacing variable: VariableName, with value: VariableName) {
         switch type {
         case .alias(let name):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/IfBlock+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/IfBlock+replaceInit.swift
@@ -64,7 +64,7 @@ extension IfBlock {
     ///   - block: The block containing all `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace `variable` with.
-    @usableFromInline
+    @inlinable
     init?(block: IfBlock, replacing variable: VariableName, with value: VariableName) {
         switch block {
         case .ifElse(let condition, let ifBlock, let elseBlock):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Machine+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Machine+replaceInit.swift
@@ -60,7 +60,7 @@ extension Machine {
     /// Create a new machine where the state code has been replaced with an encoding for state variables. This
     /// init parses the code within each state and generates new code that encodes the state variables.
     /// - Parameter machine: The machine to replace the state code in.
-    @usableFromInline
+    @inlinable
     init?(replacingStateRefsIn machine: Machine) {
         let newStates: [State] = machine.states.compactMap { State(replacingStateVariablesIn: $0) }
         guard newStates.count == machine.states.count else {

--- a/Sources/VHDLMachines/codeStructure/replaceInits/MathRealFunctionCalls+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/MathRealFunctionCalls+replaceInit.swift
@@ -66,7 +66,7 @@ extension MathRealFunctionCalls {
     ///   - function: The function containing the `variable` to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(function: MathRealFunctionCalls, replacing variable: VariableName, with value: VariableName) {
         switch function {
         case .ceil(let expression):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/State+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/State+replaceInit.swift
@@ -61,7 +61,7 @@ extension State {
 
     /// Replace the code within a state with new code that uses a states state variables.
     /// - Parameter state: The state to transform.
-    @usableFromInline
+    @inlinable
     init?(replacingStateVariablesIn state: State) {
         let newActions: [(VariableName, SynchronousBlock)] = state.actions
         .compactMap { (action: VariableName, code: SynchronousBlock) in

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Statement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Statement+replaceInit.swift
@@ -64,7 +64,7 @@ extension Statement {
     ///   - statement: The statement containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(statement: Statement, replacing variable: VariableName, with value: VariableName) {
         switch statement {
         case .assignment(let name, let expression):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Statement+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Statement+replaceInit.swift
@@ -68,8 +68,8 @@ extension Statement {
     init?(statement: Statement, replacing variable: VariableName, with value: VariableName) {
         switch statement {
         case .assignment(let name, let expression):
-            let newName = VariableReference(reference: name, replacing: variable, with: value)
             guard
+                let newName = VariableReference(reference: name, replacing: variable, with: value),
                 let newExpression = Expression(expression: expression, replacing: variable, with: value)
             else {
                 return nil

--- a/Sources/VHDLMachines/codeStructure/replaceInits/SynchronousBlock+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/SynchronousBlock+replaceInit.swift
@@ -64,7 +64,7 @@ extension SynchronousBlock {
     ///   - block: The block containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(block: SynchronousBlock, replacing variable: VariableName, with value: VariableName) {
         switch block {
         case .blocks(let blocks):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Transition+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Transition+replaceInit.swift
@@ -65,7 +65,7 @@ extension Transition {
     /// - Parameters:
     ///   - transition: The transition to convert.
     ///   - machine: The machine containing the state variables.
-    @usableFromInline
+    @inlinable
     init?(replacingStateRefsIn transition: Transition, in machine: Machine) {
         guard transition.source >= 0 && transition.source < machine.states.count else {
             return nil

--- a/Sources/VHDLMachines/codeStructure/replaceInits/TransitionCondition+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/TransitionCondition+replaceInit.swift
@@ -66,7 +66,7 @@ extension TransitionCondition {
     ///   - condition: The condition containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(condition: TransitionCondition, replacing variable: VariableName, with value: VariableName) {
         switch condition {
         case .after(let statement):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
@@ -65,11 +65,14 @@ extension VariableReference {
     ///   - variable: The variable to replace in `reference`.
     ///   - value: The new value to replace `variable` with.
     @usableFromInline
-    init(reference: VariableReference, replacing variable: VariableName, with value: VariableName) {
+    init?(reference: VariableReference, replacing variable: VariableName, with value: VariableName) {
         switch reference {
         case .indexed(let name, let index):
+            guard let newIndex = VectorIndex(index: index, replacing: variable, with: value) else {
+                return nil
+            }
             guard name == variable else {
-                self = reference
+                self = .indexed(name: name, index: newIndex)
                 return
             }
             self = .indexed(name: value, index: index)

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
@@ -64,7 +64,7 @@ extension VariableReference {
     ///   - reference: The reference containing `variable`.
     ///   - variable: The variable to replace in `reference`.
     ///   - value: The new value to replace `variable` with.
-    @usableFromInline
+    @inlinable
     init?(reference: VariableReference, replacing variable: VariableName, with value: VariableName) {
         switch reference {
         case .indexed(let name, let index):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VectorIndex+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VectorIndex+replaceInit.swift
@@ -1,4 +1,4 @@
-// Expression+replaceInit.swift
+// VectorIndex+replaceInit.swift
 // VHDLMachines
 // 
 // Created by Morgan McColl.
@@ -56,62 +56,25 @@
 
 import VHDLParsing
 
-/// Add replace initialiser.
-extension Expression {
+extension VectorIndex {
 
-    /// Replace all occurances of a `variable` in `expression` with a new `value`.
-    /// - Parameters:
-    ///   - expression: The expression containing the `variable`'s to replace.
-    ///   - variable: The variable to replace.
-    ///   - value: The new `value` to replace the `variable` with.
-    @usableFromInline
-    init?(expression: Expression, replacing variable: VariableName, with value: VariableName) {
-        switch expression {
-        case .binary(let operation):
-            guard
-                let newOperation = BinaryOperation(operation: operation, replacing: variable, with: value)
-            else {
+    init?(index: VectorIndex, replacing variable: VariableName, with value: VariableName) {
+        switch index {
+        case .index(let expression):
+            guard let newIndex = Expression(expression: expression, replacing: variable, with: value) else {
                 return nil
             }
-            self = .binary(operation: newOperation)
-        case .cast(let cast):
-            guard let newCast = CastOperation(operation: cast, replacing: variable, with: value) else {
+            self = .index(value: newIndex)
+            return
+        case .others:
+            self = .others
+            return
+        case .range(let size):
+            guard let newSize = VectorSize(size: size, replacing: variable, with: value) else {
                 return nil
             }
-            self = .cast(operation: newCast)
-        case .conditional(let condition):
-            guard let newCondition = ConditionalExpression(
-                expression: condition, replacing: variable, with: value
-            ) else {
-                return nil
-            }
-            self = .conditional(condition: newCondition)
-        case .functionCall(let call):
-            guard let newCall = FunctionCall(call: call, replacing: variable, with: value) else {
-                return nil
-            }
-            self = .functionCall(call: newCall)
-        case .literal:
-            self = expression
-        case .logical(let operation):
-            guard let newOperation = BooleanExpression(
-                expression: operation, replacing: variable, with: value
-            ) else {
-                return nil
-            }
-            self = .logical(operation: newOperation)
-        case .precedence(let expression):
-            guard let newValue = Expression(expression: expression, replacing: variable, with: value) else {
-                return nil
-            }
-            self = .precedence(value: newValue)
-        case .reference(let reference):
-            guard
-                let newReference = VariableReference(reference: reference, replacing: variable, with: value)
-            else {
-                return nil
-            }
-            self = .reference(variable: newReference)
+            self = .range(value: newSize)
+            return
         }
     }
 

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VectorIndex+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VectorIndex+replaceInit.swift
@@ -56,8 +56,15 @@
 
 import VHDLParsing
 
+/// Add replace init.
 extension VectorIndex {
 
+    /// Replace the variable with the value.
+    /// - Parameters:
+    ///   - index: The index containing the variable to replace.
+    ///   - variable: The variable to replace.
+    ///   - value: The value to replace the variable with.
+    @inlinable
     init?(index: VectorIndex, replacing variable: VariableName, with value: VariableName) {
         switch index {
         case .index(let expression):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VectorSize+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VectorSize+replaceInit.swift
@@ -64,7 +64,7 @@ extension VectorSize {
     ///   - size: The size containing the `variable`'s to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(size: VectorSize, replacing variable: VariableName, with value: VariableName) {
         switch size {
         case .downto(let upper, let lower):

--- a/Sources/VHDLMachines/codeStructure/replaceInits/WhenCase+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/WhenCase+replaceInit.swift
@@ -64,7 +64,7 @@ extension WhenCase {
     ///   - whenCase: The `WhenCase` containing the `variable`'s to replace.
     ///   - variable: The `variable` to replace.
     ///   - value: The `value` to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(whenCase: WhenCase, replacing variable: VariableName, with value: VariableName) {
         guard
             let newCondition = WhenCondition(condition: whenCase.condition, replacing: variable, with: value),

--- a/Sources/VHDLMachines/codeStructure/replaceInits/WhenCondition+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/WhenCondition+replaceInit.swift
@@ -64,7 +64,7 @@ extension WhenCondition {
     ///   - condition: The condition containing the `variable`'s to replace.
     ///   - variable: The variable to replace.
     ///   - value: The new value to replace the `variable` with.
-    @usableFromInline
+    @inlinable
     init?(condition: WhenCondition, replacing variable: VariableName, with value: VariableName) {
         switch condition {
         case .expression(let expression):

--- a/Tests/ModelImportsTests/PortSignalTests.swift
+++ b/Tests/ModelImportsTests/PortSignalTests.swift
@@ -75,7 +75,7 @@ final class PortSignalTests: XCTestCase {
         XCTAssertEqual(signal.defaultValue, .literal(value: .bit(value: .high)))
         XCTAssertEqual(signal.mode, .input)
         XCTAssertEqual(signal.name, .x)
-        XCTAssertEqual(signal.type, .stdLogic)
+        XCTAssertEqual(signal.type, .signal(type: .stdLogic))
         XCTAssertNil(signal.comment)
     }
 
@@ -91,7 +91,7 @@ final class PortSignalTests: XCTestCase {
         XCTAssertNil(signal.defaultValue)
         XCTAssertEqual(signal.mode, .input)
         XCTAssertEqual(signal.name, .x)
-        XCTAssertEqual(signal.type, .stdLogic)
+        XCTAssertEqual(signal.type, .signal(type: .stdLogic))
         XCTAssertNil(signal.comment)
     }
 

--- a/Tests/ModelImportsTests/StateTests.swift
+++ b/Tests/ModelImportsTests/StateTests.swift
@@ -80,7 +80,8 @@ final class StateTests: XCTestCase {
         name: .initial,
         actions: [
             .onEntry: .statement(statement: .assignment(
-                name: .variable(name: .y), value: .reference(variable: .variable(name: .x))
+                name: .variable(reference: .variable(name: .y)),
+                value: .reference(variable: .variable(reference: .variable(name: .x)))
             ))
         ],
         signals: [LocalSignal(type: .stdLogic, name: .y)],
@@ -93,7 +94,8 @@ final class StateTests: XCTestCase {
             name: .initial,
             actions: [
                 .onEntry: .statement(statement: .assignment(
-                    name: .variable(name: .y), value: .reference(variable: .variable(name: .x))
+                    name: .variable(reference: .variable(name: .y)),
+                    value: .reference(variable: .variable(reference: .variable(name: .x)))
                 ))
             ],
             signals: [LocalSignal(type: .stdLogic, name: .y)],
@@ -198,7 +200,8 @@ final class StateTests: XCTestCase {
         }
         expected.actions = [
             .onExit: .statement(statement: .assignment(
-                name: .variable(name: .y), value: .reference(variable: .variable(name: .x))
+                name: .variable(reference: .variable(name: .y)),
+                value: .reference(variable: .variable(reference: .variable(name: .x)))
             ))
         ]
         XCTAssertEqual(state, expected)

--- a/Tests/TestUtils/Machine+testMachine.swift
+++ b/Tests/TestUtils/Machine+testMachine.swift
@@ -76,8 +76,8 @@ extension Machine {
             path: directory.appendingPathComponent("TestMachine.machine", isDirectory: true),
             includes: [
                 .library(value: VariableName(rawValue: "IEEE")!),
-                .include(statement: UseStatement(rawValue: "IEEE.std_logic_1164.ALL")!),
-                .include(statement: UseStatement(rawValue: "IEEE.math_real.ALL")!)
+                .include(statement: UseStatement(rawValue: "use IEEE.std_logic_1164.ALL;")!),
+                .include(statement: UseStatement(rawValue: "use IEEE.math_real.ALL;")!)
             ],
             externalSignals: [
                 PortSignal(

--- a/Tests/TestUtils/Machine+testMachine.swift
+++ b/Tests/TestUtils/Machine+testMachine.swift
@@ -68,16 +68,16 @@ extension Machine {
     public static func testMachine(directory: URL = PingPongArrangement().machinePath) -> Machine {
         var initialState = State.defaultState(name: .initial)
         initialState.actions[.onEntry] = .statement(statement: .assignment(
-            name: .variable(name: .z), value: .literal(value: .bit(value: .low))
+            name: .variable(reference: .variable(name: .z)), value: .literal(value: .bit(value: .low))
         ))
         var machine = VHDLMachines.Machine(
             actions: [.onEntry, .internal, .onExit, .onResume, .onSuspend],
             name: VariableName(rawValue: "TestMachine")!,
             path: directory.appendingPathComponent("TestMachine.machine", isDirectory: true),
             includes: [
-                .library(value: "IEEE"),
-                .include(value: "IEEE.std_logic_1164.ALL"),
-                .include(value: "IEEE.math_real.ALL")
+                .library(value: VariableName(rawValue: "IEEE")!),
+                .include(statement: UseStatement(rawValue: "IEEE.std_logic_1164.ALL")!),
+                .include(statement: UseStatement(rawValue: "IEEE.math_real.ALL")!)
             ],
             externalSignals: [
                 PortSignal(
@@ -168,7 +168,7 @@ extension Machine {
             transitions: [
                 VHDLMachines.Transition(
                     condition: .conditional(condition: .comparison(value: .equality(
-                        lhs: .reference(variable: .variable(name: .z)),
+                        lhs: .reference(variable: .variable(reference: .variable(name: .z))),
                         rhs: .literal(value: .bit(value: .high))
                     ))),
                     source: 0,
@@ -204,7 +204,7 @@ extension Machine {
                     // "xx = \"11\""
                     condition: .conditional(condition: .comparison(
                         value: .equality(
-                            lhs: .reference(variable: .variable(name: .xx)),
+                            lhs: .reference(variable: .variable(reference: .variable(name: .xx))),
                             rhs: .literal(value: .vector(
                                 value: .bits(value: BitVector(values: [.high, .high]))
                             ))
@@ -217,7 +217,7 @@ extension Machine {
                     // // "x = '1'"
                     condition: .conditional(condition: .comparison(
                         value: .equality(
-                            lhs: .reference(variable: .variable(name: .x)),
+                            lhs: .reference(variable: .variable(reference: .variable(name: .x))),
                             rhs: .literal(value: .bit(value: .high))
                         )
                     )),

--- a/Tests/TestUtils/PingPongArrangement.swift
+++ b/Tests/TestUtils/PingPongArrangement.swift
@@ -186,11 +186,16 @@ public struct PingPongArrangement {
     )
 
     /// The includes.
-    public let includes: [Include] = [
-        .library(value: VariableName(rawValue: "IEEE")!),
-        .include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!),
-        .include(statement: UseStatement(rawValue: "IEEE.NUMERIC_STD.ALL")!)
-    ]
+    public let includes: [Include] = {
+        guard let stdLogicImport = UseStatement(rawValue: "use IEEE.STD_LOGIC_1164.ALL;") else {
+            fatalError("Failed")
+        }
+        return [
+            .library(value: VariableName(rawValue: "IEEE")!),
+            .include(statement: stdLogicImport),
+            .include(statement: UseStatement(rawValue: "use IEEE.NUMERIC_STD.ALL;")!)
+        ]
+    }()
 
     /// The ping machine.
     public var pingMachine: Machine {
@@ -254,8 +259,8 @@ public struct PingPongArrangement {
     /// The VHDL code for the Ping machine.
     public let pingCode = """
     library IEEE;
-    use IEEE.STD_LOGIC_1164.ALL;
-    use IEEE.NUMERIC_STD.ALL;
+    use IEEE.STD_LOGIC_1164.all;
+    use IEEE.NUMERIC_STD.all;
 
     entity PingMachine is
         port(

--- a/Tests/TestUtils/PingPongArrangement.swift
+++ b/Tests/TestUtils/PingPongArrangement.swift
@@ -163,7 +163,7 @@ public struct PingPongArrangement {
     /// The ping wait states transition.
     public let pingWaitTransition = Transition(
         condition: .conditional(condition: .comparison(value: .equality(
-            lhs: .reference(variable: .variable(name: VariableName(rawValue: "pong")!)),
+            lhs: .reference(variable: .variable(reference: .variable(name: VariableName(rawValue: "pong")!))),
             rhs: .literal(value: .bit(value: .high))
         ))),
         source: 1,
@@ -178,7 +178,7 @@ public struct PingPongArrangement {
     /// The pong wait states transition.
     public let pongWaitTransition = Transition(
         condition: .conditional(condition: .comparison(value: .equality(
-            lhs: .reference(variable: .variable(name: VariableName(rawValue: "ping")!)),
+            lhs: .reference(variable: .variable(reference: .variable(name: VariableName(rawValue: "ping")!))),
             rhs: .literal(value: .bit(value: .high))
         ))),
         source: 0,
@@ -187,9 +187,9 @@ public struct PingPongArrangement {
 
     /// The includes.
     public let includes: [Include] = [
-        .library(value: "IEEE"),
-        .include(value: "IEEE.STD_LOGIC_1164.ALL"),
-        .include(value: "IEEE.NUMERIC_STD.ALL")
+        .library(value: VariableName(rawValue: "IEEE")!),
+        .include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!),
+        .include(statement: UseStatement(rawValue: "IEEE.NUMERIC_STD.ALL")!)
     ]
 
     /// The ping machine.

--- a/Tests/VHDLMachinesTests/MachineTests.swift
+++ b/Tests/VHDLMachinesTests/MachineTests.swift
@@ -78,8 +78,8 @@ final class MachineTests: XCTestCase {
     /// The includes for the machine.
     var includes: [Include] {
         [
-            .include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!),
-            .include(statement: UseStatement(rawValue: "IEEE.NUMERIC_STD.ALL")!)
+            .include(statement: UseStatement(rawValue: "use IEEE.STD_LOGIC_1164.ALL;")!),
+            .include(statement: UseStatement(rawValue: "use IEEE.NUMERIC_STD.ALL;")!)
         ]
     }
 
@@ -288,7 +288,9 @@ final class MachineTests: XCTestCase {
     func testGettersAndSetters() {
         let newMachineName = VariableName(rawValue: "M3")!
         let newPath = URL(fileURLWithPath: "/path/to/M3")
-        let newIncludes = [Include.include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!)]
+        let newIncludes = [
+            Include.include(statement: UseStatement(rawValue: "use IEEE.STD_LOGIC_1164.ALL;")!)
+        ]
         let newExternalSignals = [
             PortSignal(
                 type: .stdLogic,
@@ -393,8 +395,8 @@ final class MachineTests: XCTestCase {
             path: path,
             includes: [
                 .library(value: VariableName(rawValue: "IEEE")!),
-                .include(statement: UseStatement(rawValue: "IEEE.std_logic_1164.All")!),
-                .include(statement: UseStatement(rawValue: "IEEE.math_real.All")!)
+                .include(statement: UseStatement(rawValue: "use IEEE.std_logic_1164.All;")!),
+                .include(statement: UseStatement(rawValue: "use IEEE.math_real.All;")!)
             ],
             externalSignals: [],
             clocks: [Clock(name: VariableName.clk, frequency: 50, unit: .MHz)],

--- a/Tests/VHDLMachinesTests/MachineTests.swift
+++ b/Tests/VHDLMachinesTests/MachineTests.swift
@@ -70,8 +70,6 @@ final class MachineTests: XCTestCase {
         VariableName(rawValue: "M0")!
     }
 
-    // swiftlint:enable force_unwrapping
-
     /// The path to the machine.
     var path: URL {
         URL(fileURLWithPath: "/path/to/M0")
@@ -80,10 +78,12 @@ final class MachineTests: XCTestCase {
     /// The includes for the machine.
     var includes: [Include] {
         [
-            .include(value: "IEEE.STD_LOGIC_1164.ALL"),
-            .include(value: "IEEE.NUMERIC_STD.ALL")
+            .include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!),
+            .include(statement: UseStatement(rawValue: "IEEE.NUMERIC_STD.ALL")!)
         ]
     }
+
+    // swiftlint:enable force_unwrapping
 
     /// The external signals for the machine.
     var externalSignals: [PortSignal] {
@@ -203,7 +203,8 @@ final class MachineTests: XCTestCase {
     /// The architecture body for the machine.
     var architectureBody: AsynchronousBlock {
         .statement(statement: .assignment(
-            name: .variable(name: .s), value: .literal(value: .bit(value: .high))
+            name: .variable(reference: .variable(name: .s)),
+            value: .expression(value: .literal(value: .bit(value: .high)))
         ))
     }
 
@@ -287,7 +288,7 @@ final class MachineTests: XCTestCase {
     func testGettersAndSetters() {
         let newMachineName = VariableName(rawValue: "M3")!
         let newPath = URL(fileURLWithPath: "/path/to/M3")
-        let newIncludes = [Include.include(value: "IEEE.STD_LOGIC_1164.ALL")]
+        let newIncludes = [Include.include(statement: UseStatement(rawValue: "IEEE.STD_LOGIC_1164.ALL")!)]
         let newExternalSignals = [
             PortSignal(
                 type: .stdLogic,
@@ -345,7 +346,8 @@ final class MachineTests: XCTestCase {
             ))
         ]
         let newArchitectureBody = AsynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .g), value: .literal(value: .bit(value: .low))
+            name: .variable(reference: .variable(name: .g)),
+            value: .expression(value: .literal(value: .bit(value: .low)))
         ))
         machine.name = newMachineName
         machine.path = newPath
@@ -390,9 +392,9 @@ final class MachineTests: XCTestCase {
             name: VariableName(rawValue: "NewMachine")!,
             path: path,
             includes: [
-                .library(value: "IEEE"),
-                .include(value: "IEEE.std_logic_1164.All"),
-                .include(value: "IEEE.math_real.All")
+                .library(value: VariableName(rawValue: "IEEE")!),
+                .include(statement: UseStatement(rawValue: "IEEE.std_logic_1164.All")!),
+                .include(statement: UseStatement(rawValue: "IEEE.math_real.All")!)
             ],
             externalSignals: [],
             clocks: [Clock(name: VariableName.clk, frequency: 50, unit: .MHz)],

--- a/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
+++ b/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
@@ -173,8 +173,8 @@ class VHDLMachinesCompilerTests: XCTestCase {
     /// The vhdl code for the test machine.
     private let vhdl = """
         library IEEE;
-        use IEEE.std_logic_1164.ALL;
-        use IEEE.math_real.ALL;
+        use IEEE.std_logic_1164.all;
+        use IEEE.math_real.all;
 
         entity TestMachine is
             port(

--- a/Tests/VHDLMachinesTests/codeStructure/AfterStatementTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/AfterStatementTests.swift
@@ -62,7 +62,7 @@ import XCTest
 final class AfterStatementTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// The ringletCounter raw value.
     let ringletCounter = VariableName.ringletCounter.rawValue
@@ -199,11 +199,11 @@ final class AfterStatementTests: XCTestCase {
         XCTAssertEqual(
             statement.expression,
             .precedence(value: .conditional(condition: .comparison(value: .greaterThanOrEqual(
-                lhs: .reference(variable: .variable(name: .ringletCounter)),
+                lhs: .reference(variable: .variable(reference: .variable(name: .ringletCounter))),
                 rhs: .cast(operation: .integer(expression: .functionCall(call: .mathReal(function: .ceil(
                     expression: .binary(operation: .multiplication(
                         lhs: .cast(operation: .real(expression: .literal(value: .integer(value: 10)))),
-                        rhs: .reference(variable: .variable(name: .ringletPerUs))
+                        rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerUs)))
                     ))
                 )))))
             ))))
@@ -212,7 +212,7 @@ final class AfterStatementTests: XCTestCase {
         XCTAssertEqual(
             ringletStatement.expression,
             .precedence(value: .conditional(condition: .comparison(value: .greaterThanOrEqual(
-                lhs: .reference(variable: .variable(name: .ringletCounter)),
+                lhs: .reference(variable: .variable(reference: .variable(name: .ringletCounter))),
                 rhs: .cast(operation: .integer(expression: .functionCall(call: .mathReal(function: .ceil(
                     expression: .cast(operation: .real(expression: .literal(value: .integer(value: 5))))
                 )))))

--- a/Tests/VHDLMachinesTests/codeStructure/ArchitectureHeadTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/ArchitectureHeadTests.swift
@@ -164,7 +164,7 @@ final class ArchitectureHeadTests: XCTestCase {
             .definition(value: .signal(value: LocalSignal(
                 type: internalStateType,
                 name: .internalState,
-                defaultValue: .reference(variable: .variable(name: .readSnapshot)),
+                defaultValue: .reference(variable: .variable(reference: .variable(name: .readSnapshot))),
                 comment: nil
             ))),
             .comment(value: Comment(rawValue: "-- State Representation Bits")!),
@@ -195,17 +195,17 @@ final class ArchitectureHeadTests: XCTestCase {
             .definition(value: .signal(value: LocalSignal(
                 type: stateType,
                 name: .currentState,
-                defaultValue: .reference(variable: .variable(
+                defaultValue: .reference(variable: .variable(reference: .variable(
                     name: VariableName(rawValue: "STATE_\(VariableName.suspendedState)")!
-                )),
+                ))),
                 comment: nil
             ))),
             .definition(value: .signal(value: LocalSignal(
                 type: stateType,
                 name: .targetState,
-                defaultValue: .reference(variable: .variable(
+                defaultValue: .reference(variable: .variable(reference: .variable(
                     name: VariableName(rawValue: "STATE_\(VariableName.suspendedState)")!
-                )),
+                ))),
                 comment: nil
             ))),
             .definition(value: .signal(value: LocalSignal(
@@ -219,9 +219,9 @@ final class ArchitectureHeadTests: XCTestCase {
             .definition(value: .signal(value: LocalSignal(
                 type: stateType,
                 name: .suspendedFrom,
-                defaultValue: .reference(variable: .variable(
+                defaultValue: .reference(variable: .variable(reference: .variable(
                     name: VariableName(rawValue: "STATE_\(VariableName.initial)")!
-                )),
+                ))),
                 comment: nil
             ))),
             .comment(value: Comment(rawValue: "-- Suspension Commands")!),
@@ -275,7 +275,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .multiplication(
                     lhs: .literal(value: .decimal(value: 5.0)),
-                    rhs: .reference(variable: .variable(name: .clockPeriod))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .clockPeriod)))
                 ))
             )!)),
             .definition(value: .constant(value: ConstantSignal(
@@ -283,7 +283,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .division(
                     lhs: .literal(value: .decimal(value: 1.0)),
-                    rhs: .reference(variable: .variable(name: .ringletLength))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .ringletLength)))
                 ))
             )!)),
             .definition(value: .constant(value: ConstantSignal(
@@ -291,7 +291,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .multiplication(
                     lhs: .literal(value: .decimal(value: 1000.0)),
-                    rhs: .reference(variable: .variable(name: .ringletPerPs))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
                 ))
             )!)),
             .definition(value: .constant(value: ConstantSignal(
@@ -299,7 +299,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .multiplication(
                     lhs: .literal(value: .decimal(value: 1_000_000.0)),
-                    rhs: .reference(variable: .variable(name: .ringletPerPs))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
                 ))
             )!)),
             .definition(value: .constant(value: ConstantSignal(
@@ -307,7 +307,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .multiplication(
                     lhs: .literal(value: .decimal(value: 1_000_000_000.0)),
-                    rhs: .reference(variable: .variable(name: .ringletPerPs))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
                 ))
             )!)),
             .definition(value: .constant(value: ConstantSignal(
@@ -315,7 +315,7 @@ final class ArchitectureHeadTests: XCTestCase {
                 type: .real,
                 value: .binary(operation: .multiplication(
                     lhs: .literal(value: .decimal(value: 1_000_000_000_000.0)),
-                    rhs: .reference(variable: .variable(name: .ringletPerPs))
+                    rhs: .reference(variable: .variable(reference: .variable(name: .ringletPerPs)))
                 ))
             )!)),
             .comment(value: Comment(rawValue: "-- Snapshot of External Signals and Variables")!),

--- a/Tests/VHDLMachinesTests/codeStructure/AsynchronousBlockTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/AsynchronousBlockTests.swift
@@ -79,7 +79,8 @@ final class AsynchronousBlockTests: XCTestCase {
     func testMachineInitWithUserCode() {
         var machine = Machine.testMachine()
         let xAssignment = AsynchronousBlock.statement(statement: .assignment(
-            name: .variable(name: .x), value: .literal(value: .bit(value: .high))
+            name: .variable(reference: .variable(name: .x)),
+            value: .expression(value: .literal(value: .bit(value: .high)))
         ))
         machine.architectureBody = xAssignment
         let result = AsynchronousBlock(machine: machine)

--- a/Tests/VHDLMachinesTests/codeStructure/CaseStatementTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/CaseStatementTests.swift
@@ -89,7 +89,7 @@ final class CaseStatementTests: XCTestCase {
         XCTAssertEqual(
             statement,
             CaseStatement(
-                condition: .reference(variable: .variable(name: .internalState)),
+                condition: .reference(variable: .variable(reference: .variable(name: .internalState))),
                 cases: [
                     checkTransition,
                     `internal`,
@@ -135,7 +135,7 @@ final class CaseStatementTests: XCTestCase {
         XCTAssertEqual(
             statement,
             CaseStatement(
-                condition: .reference(variable: .variable(name: .internalState)),
+                condition: .reference(variable: .variable(reference: .variable(name: .internalState))),
                 cases: [
                     checkTransition,
                     `internal`,
@@ -171,7 +171,7 @@ final class CaseStatementTests: XCTestCase {
         XCTAssertEqual(
             statement,
             CaseStatement(
-                condition: .reference(variable: .variable(name: .internalState)),
+                condition: .reference(variable: .variable(reference: .variable(name: .internalState))),
                 cases: [
                     checkTransition,
                     `internal`,

--- a/Tests/VHDLMachinesTests/codeStructure/LocalSignalTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/LocalSignalTests.swift
@@ -92,7 +92,7 @@ final class LocalSignalTests: XCTestCase {
                     type: type,
                     name: .currentState,
                     defaultValue: .reference(
-                        variable: .variable(name: VariableName.name(for: suspendedState))
+                        variable: .variable(reference: .variable(name: .name(for: suspendedState)))
                     ),
                     comment: nil
                 ),
@@ -100,7 +100,7 @@ final class LocalSignalTests: XCTestCase {
                     type: type,
                     name: .targetState,
                     defaultValue: .reference(
-                        variable: .variable(name: VariableName.name(for: suspendedState))
+                        variable: .variable(reference: .variable(name: .name(for: suspendedState)))
                     ),
                     comment: nil
                 ),
@@ -115,7 +115,9 @@ final class LocalSignalTests: XCTestCase {
                 LocalSignal(
                     type: type,
                     name: .suspendedFrom,
-                    defaultValue: .reference(variable: .variable(name: VariableName.name(for: initialState))),
+                    defaultValue: .reference(variable: .variable(
+                        reference: .variable(name: .name(for: initialState))
+                    )),
                     comment: nil
                 )
             ]

--- a/Tests/VHDLMachinesTests/codeStructure/PortSignalTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/PortSignalTests.swift
@@ -79,13 +79,15 @@ final class PortSignalTests: XCTestCase {
         XCTAssertEqual(
             signal.read,
             .assignment(
-                name: .variable(name: .x), value: .reference(variable: .variable(name: signal.externalName))
+                name: .variable(reference: .variable(name: .x)),
+                value: .reference(variable: .variable(reference: .variable(name: signal.externalName)))
             )
         )
         XCTAssertEqual(
             signal.write,
             .assignment(
-                name: .variable(name: signal.externalName), value: .reference(variable: .variable(name: .x))
+                name: .variable(reference: .variable(name: signal.externalName)),
+                value: .reference(variable: .variable(reference: .variable(name: .x)))
             )
         )
     }
@@ -96,7 +98,7 @@ final class PortSignalTests: XCTestCase {
         let signal = PortSignal(clock: clock)
         XCTAssertEqual(signal.name, .clk)
         XCTAssertEqual(signal.mode, .input)
-        XCTAssertEqual(signal.type, .stdLogic)
+        XCTAssertEqual(signal.type, .signal(type: .stdLogic))
         XCTAssertNil(signal.defaultValue)
         XCTAssertNil(signal.comment)
     }

--- a/Tests/VHDLMachinesTests/codeStructure/SynchronousBlockTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/SynchronousBlockTests.swift
@@ -73,7 +73,9 @@ final class SynchronousBlockTests: XCTestCase {
             result,
             .ifStatement(block: .ifStatement(
                 condition: .conditional(condition: .edge(
-                    value: .rising(expression: .reference(variable: .variable(name: .clk)))
+                    value: .rising(expression: .reference(
+                        variable: .variable(reference: .variable(name: .clk))
+                    ))
                 )),
                 ifBlock: .caseStatement(block: statement)
             ))

--- a/Tests/VHDLMachinesTests/codeStructure/TransitionConditionTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/TransitionConditionTests.swift
@@ -63,13 +63,13 @@ import XCTest
 final class TransitionConditionTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A variable `y`
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     /// A variable `z`
-    let z = Expression.reference(variable: .variable(name: .z))
+    let z = Expression.reference(variable: .variable(reference: .variable(name: .z)))
 
     /// Test that raw values are correct.
     func testRawValue() {

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/AfterStatementInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/AfterStatementInitTests.swift
@@ -62,7 +62,7 @@ import XCTest
 final class AfterStatementInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     // swiftlint:disable force_unwrapping
 
@@ -73,7 +73,7 @@ final class AfterStatementInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test init replaces expression correctly.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/AsynchronousExpressionTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/AsynchronousExpressionTests.swift
@@ -1,0 +1,133 @@
+// AsynchronousExpressionTests.swift
+// VHDLMachines
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLMachines
+import VHDLParsing
+import XCTest
+
+/// Test class for `AsynchronousExpression` extensions.
+final class AsynchronousExpressionTests: XCTestCase {
+
+    // swiftlint:disable function_body_length
+
+    /// Test replace init.
+    func testReplaceInit() {
+        let original = AsynchronousExpression.whenBlock(value: WhenBlock.whenElse(
+            statement: WhenElseStatement(
+                value: .reference(variable: .variable(reference: .variable(name: .x))),
+                condition: .conditional(condition: .comparison(value: .equality(
+                    lhs: .reference(variable: .variable(reference: .variable(name: .y))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .z)))
+                ))),
+                elseBlock: .expression(value: .reference(variable: .variable(reference: .variable(name: .a))))
+            )
+        ))
+        let replaceX = AsynchronousExpression(expression: original, replacing: .x, with: .xs)
+        let expected = AsynchronousExpression.whenBlock(value: WhenBlock.whenElse(
+            statement: WhenElseStatement(
+                value: .reference(variable: .variable(reference: .variable(name: .xs))),
+                condition: .conditional(condition: .comparison(value: .equality(
+                    lhs: .reference(variable: .variable(reference: .variable(name: .y))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .z)))
+                ))),
+                elseBlock: .expression(value: .reference(variable: .variable(reference: .variable(name: .a))))
+            )
+        ))
+        XCTAssertEqual(replaceX, expected)
+        let replaceY = AsynchronousExpression(expression: original, replacing: .y, with: .clk)
+        let expected2 = AsynchronousExpression.whenBlock(value: WhenBlock.whenElse(
+            statement: WhenElseStatement(
+                value: .reference(variable: .variable(reference: .variable(name: .x))),
+                condition: .conditional(condition: .comparison(value: .equality(
+                    lhs: .reference(variable: .variable(reference: .variable(name: .clk))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .z)))
+                ))),
+                elseBlock: .expression(value: .reference(variable: .variable(reference: .variable(name: .a))))
+            )
+        ))
+        XCTAssertEqual(replaceY, expected2)
+        let replaceZ = AsynchronousExpression(expression: original, replacing: .z, with: .clk2)
+        let expected3 = AsynchronousExpression.whenBlock(value: WhenBlock.whenElse(
+            statement: WhenElseStatement(
+                value: .reference(variable: .variable(reference: .variable(name: .x))),
+                condition: .conditional(condition: .comparison(value: .equality(
+                    lhs: .reference(variable: .variable(reference: .variable(name: .y))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .clk2)))
+                ))),
+                elseBlock: .expression(value: .reference(variable: .variable(reference: .variable(name: .a))))
+            )
+        ))
+        XCTAssertEqual(replaceZ, expected3)
+        let replaceA = AsynchronousExpression(expression: original, replacing: .a, with: .g)
+        let expected4 = AsynchronousExpression.whenBlock(value: WhenBlock.whenElse(
+            statement: WhenElseStatement(
+                value: .reference(variable: .variable(reference: .variable(name: .x))),
+                condition: .conditional(condition: .comparison(value: .equality(
+                    lhs: .reference(variable: .variable(reference: .variable(name: .y))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: .z)))
+                ))),
+                elseBlock: .expression(value: .reference(variable: .variable(reference: .variable(name: .g))))
+            )
+        ))
+        XCTAssertEqual(replaceA, expected4)
+        XCTAssertEqual(
+            original, AsynchronousExpression(expression: original, replacing: .checkTransition, with: .x)
+        )
+    }
+
+    // swiftlint:enable function_body_length
+
+}

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/AsynchronousStatementTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/AsynchronousStatementTests.swift
@@ -1,0 +1,91 @@
+// AsynchronousStatementTests.swift
+// VHDLMachines
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLMachines
+import VHDLParsing
+import XCTest
+
+/// Test class for `AsynchronousStatement` extensions.
+final class AsynchronousStatementTests: XCTestCase {
+
+    /// Test replace init.
+    func testReplaceInit() {
+        let original = AsynchronousStatement.assignment(
+            name: .variable(reference: .variable(name: .x)),
+            value: .expression(value: .reference(variable: .variable(reference: .variable(name: .y))))
+        )
+        let replaceX = AsynchronousStatement(statement: original, replacing: .x, with: .xs)
+        let expected = AsynchronousStatement.assignment(
+            name: .variable(reference: .variable(name: .xs)),
+            value: .expression(value: .reference(variable: .variable(reference: .variable(name: .y))))
+        )
+        XCTAssertEqual(replaceX, expected)
+        let replaceY = AsynchronousStatement(statement: original, replacing: .y, with: .clk)
+        let expected2 = AsynchronousStatement.assignment(
+            name: .variable(reference: .variable(name: .x)),
+            value: .expression(value: .reference(variable: .variable(reference: .variable(name: .clk))))
+        )
+        XCTAssertEqual(replaceY, expected2)
+        // swiftlint:disable:next force_unwrapping
+        let comment = AsynchronousStatement.comment(value: Comment(rawValue: "-- A Comment!")!)
+        let replaceComment = AsynchronousStatement(statement: comment, replacing: .x, with: .xs)
+        XCTAssertEqual(replaceComment, comment)
+        XCTAssertEqual(
+            original, AsynchronousStatement(statement: original, replacing: .checkTransition, with: .g)
+        )
+    }
+
+}

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/BinaryOperationInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/BinaryOperationInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class BinaryOperationInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class BinaryOperationInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `addition` operation.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/BooleanExpressionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/BooleanExpressionInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class BooleanExpressionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class BooleanExpressionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `and` operation.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/CaseStatementInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/CaseStatementInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class CaseStatementInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class CaseStatementInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test that the condition is replaced correctly.
@@ -93,7 +93,9 @@ final class CaseStatementInitTests: XCTestCase {
             WhenCase(condition: .expression(expression: x), code: .statement(statement: .null)),
             WhenCase(
                 condition: .expression(expression: y),
-                code: .statement(statement: .assignment(name: .variable(name: .y), value: x))
+                code: .statement(statement: .assignment(
+                    name: .variable(reference: .variable(name: .y)), value: x
+                ))
             )
         ]
         let original = CaseStatement(condition: y, cases: cases)
@@ -102,7 +104,9 @@ final class CaseStatementInitTests: XCTestCase {
             WhenCase(condition: .expression(expression: expNewX), code: .statement(statement: .null)),
             WhenCase(
                 condition: .expression(expression: y),
-                code: .statement(statement: .assignment(name: .variable(name: .y), value: expNewX))
+                code: .statement(statement: .assignment(
+                    name: .variable(reference: .variable(name: .y)), value: expNewX
+                ))
             )
         ]))
     }

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/CastOperationInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/CastOperationInitTests.swift
@@ -62,7 +62,7 @@ import XCTest
 final class CastOperationInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     // swiftlint:disable force_unwrapping
 
@@ -73,7 +73,7 @@ final class CastOperationInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `bit` cast.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/ComparisonOperationInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/ComparisonOperationInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class ComparisonOperationInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class ComparisonOperationInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `equality` operation.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/ConditionalExpressionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/ConditionalExpressionInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class ConditionalExpressionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class ConditionalExpressionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test comparisons.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/EdgeConditionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/EdgeConditionInitTests.swift
@@ -62,7 +62,7 @@ import XCTest
 final class EdgeConditionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     // swiftlint:disable force_unwrapping
 
@@ -73,7 +73,7 @@ final class EdgeConditionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test the `rising` case.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/ExpressionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/ExpressionInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class ExpressionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class ExpressionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `binary` case.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/ForLoopInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/ForLoopInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class ForLoopInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class ForLoopInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test replace init replaces the correct variables in range.
@@ -101,7 +101,9 @@ final class ForLoopInitTests: XCTestCase {
         let original = ForLoop(
             iterator: .z,
             range: range,
-            body: .statement(statement: .assignment(name: .variable(name: .y), value: x))
+            body: .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: .y)), value: x
+            ))
         )
         let result = ForLoop(loop: original, replacing: .x, with: newX)
         XCTAssertEqual(
@@ -109,7 +111,9 @@ final class ForLoopInitTests: XCTestCase {
             ForLoop(
                 iterator: .z,
                 range: range,
-                body: .statement(statement: .assignment(name: .variable(name: .y), value: expNewX))
+                body: .statement(statement: .assignment(
+                    name: .variable(reference: .variable(name: .y)), value: expNewX
+                ))
             )
         )
     }

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionCallsInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionCallsInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class FunctionCallsInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class FunctionCallsInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `mathReal` case.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionImplementationTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionImplementationTests.swift
@@ -1,0 +1,133 @@
+// FunctionImplementationTests.swift
+// VHDLMachines
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLMachines
+import VHDLParsing
+import XCTest
+
+/// Test class for `FunctionImplementation` extensions.
+final class FunctionImplementationTests: XCTestCase {
+
+    // swiftlint:disable function_body_length
+
+    /// Test replace init.
+    func testReplaceInit() {
+        let original = FunctionImplementation(
+            name: .g,
+            arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
+            returnTube: .alias(name: .z),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .a)))
+            ))
+        )
+        let replaceG = FunctionImplementation(function: original, replacing: .g, with: .clk)
+        let expected = FunctionImplementation(
+            name: .clk,
+            arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
+            returnTube: .alias(name: .z),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .a)))
+            ))
+        )
+        XCTAssertEqual(replaceG, expected)
+        let replaceX = FunctionImplementation(function: original, replacing: .x, with: .xs)
+        let expected2 = FunctionImplementation(
+            name: .g,
+            arguments: [ArgumentDefinition(name: .xs, type: .alias(name: .y))],
+            returnTube: .alias(name: .z),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .a)))
+            ))
+        )
+        XCTAssertEqual(replaceX, expected2)
+        let replaceY = FunctionImplementation(function: original, replacing: .y, with: .clk2)
+        let expected3 = FunctionImplementation(
+            name: .g,
+            arguments: [ArgumentDefinition(name: .x, type: .alias(name: .clk2))],
+            returnTube: .alias(name: .z),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .a)))
+            ))
+        )
+        XCTAssertEqual(replaceY, expected3)
+        let replaceZ = FunctionImplementation(function: original, replacing: .z, with: .command)
+        let expected4 = FunctionImplementation(
+            name: .g,
+            arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
+            returnTube: .alias(name: .command),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .a)))
+            ))
+        )
+        XCTAssertEqual(replaceZ, expected4)
+        let replaceA = FunctionImplementation(function: original, replacing: .a, with: .internal)
+        let expected5 = FunctionImplementation(
+            name: .g,
+            arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
+            returnTube: .alias(name: .z),
+            body: .statement(statement: .returns(
+                value: .reference(variable: .variable(reference: .variable(name: .internal)))
+            ))
+        )
+        XCTAssertEqual(replaceA, expected5)
+        XCTAssertEqual(
+            original, FunctionImplementation(function: original, replacing: .xx, with: .targetState)
+        )
+    }
+
+    // swiftlint:enable function_body_length
+
+}

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/IfBlockInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/IfBlockInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class IfBlockInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class IfBlockInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test simple statement condition.
@@ -89,14 +89,19 @@ final class IfBlockInitTests: XCTestCase {
     /// Test statement block.
     func testStatementBlock() {
         let original = IfBlock.ifStatement(
-            condition: y, ifBlock: .statement(statement: .assignment(name: .variable(name: .x), value: y))
+            condition: y,
+            ifBlock: .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: .x)), value: y
+            ))
         )
         let result = IfBlock(block: original, replacing: .x, with: newX)
         XCTAssertEqual(
             result,
             IfBlock.ifStatement(
                 condition: y,
-                ifBlock: .statement(statement: .assignment(name: .variable(name: newX), value: y))
+                ifBlock: .statement(statement: .assignment(
+                    name: .variable(reference: .variable(name: newX)), value: y
+                ))
             )
         )
     }
@@ -121,7 +126,9 @@ final class IfBlockInitTests: XCTestCase {
     func testIfElseStatement() {
         let original = IfBlock.ifElse(
             condition: y,
-            ifBlock: .statement(statement: .assignment(name: .variable(name: .x), value: y)),
+            ifBlock: .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: .x)), value: y
+            )),
             elseBlock: .statement(statement: .null)
         )
         let result = IfBlock(block: original, replacing: .x, with: newX)
@@ -129,7 +136,9 @@ final class IfBlockInitTests: XCTestCase {
             result,
             IfBlock.ifElse(
                 condition: y,
-                ifBlock: .statement(statement: .assignment(name: .variable(name: newX), value: y)),
+                ifBlock: .statement(
+                    statement: .assignment(name: .variable(reference: .variable(name: newX)), value: y)
+                ),
                 elseBlock: .statement(statement: .null)
             )
         )
@@ -140,7 +149,9 @@ final class IfBlockInitTests: XCTestCase {
         let original = IfBlock.ifElse(
             condition: y,
             ifBlock: .statement(statement: .null),
-            elseBlock: .statement(statement: .assignment(name: .variable(name: .x), value: y))
+            elseBlock: .statement(
+                statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)
+            )
         )
         let result = IfBlock(block: original, replacing: .x, with: newX)
         XCTAssertEqual(
@@ -148,7 +159,9 @@ final class IfBlockInitTests: XCTestCase {
             IfBlock.ifElse(
                 condition: y,
                 ifBlock: .statement(statement: .null),
-                elseBlock: .statement(statement: .assignment(name: .variable(name: newX), value: y))
+                elseBlock: .statement(
+                    statement: .assignment(name: .variable(reference: .variable(name: newX)), value: y)
+                )
             )
         )
     }

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/MachineInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/MachineInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class MachineInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -79,12 +79,12 @@ final class MachineInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// `newY` as an expression.
     var expNewY: Expression {
-        .reference(variable: .variable(name: newY))
+        .reference(variable: .variable(reference: .variable(name: newY)))
     }
 
     /// Test that all states are replaced correctly.
@@ -96,19 +96,19 @@ final class MachineInitTests: XCTestCase {
         machine.states[0].signals = [LocalSignal(type: .stdLogic, name: .x)]
         machine.states[1].signals = [LocalSignal(type: .stdLogic, name: .y)]
         machine.states[0].actions[.onEntry] = .statement(
-            statement: .assignment(name: .variable(name: .x), value: y)
+            statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)
         )
         machine.states[1].actions[.onEntry] = .statement(
-            statement: .assignment(name: .variable(name: .x), value: y)
+            statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)
         )
         machine.states = [machine.states[0], machine.states[1]]
         var expected = machine
         let result = Machine(replacingStateRefsIn: machine)
         expected.states[0].actions[.onEntry] = .statement(
-            statement: .assignment(name: .variable(name: newX), value: y)
+            statement: .assignment(name: .variable(reference: .variable(name: newX)), value: y)
         )
         expected.states[1].actions[.onEntry] = .statement(
-            statement: .assignment(name: .variable(name: .x), value: expNewY)
+            statement: .assignment(name: .variable(reference: .variable(name: .x)), value: expNewY)
         )
         expected.transitions = [Transition(condition: .variable(name: newX), source: 0, target: 1)]
         XCTAssertEqual(result, expected)

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/MathRealFunctionCallsInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/MathRealFunctionCallsInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class MathRealFunctionCallsInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class MathRealFunctionCallsInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `ceil` function.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/StateInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/StateInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class StateInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -79,12 +79,12 @@ final class StateInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// `newY` as an expression.
     var expNewY: Expression {
-        .reference(variable: .variable(name: newY))
+        .reference(variable: .variable(reference: .variable(name: newY)))
     }
 
     /// Test init replaces variables correctly.
@@ -94,21 +94,25 @@ final class StateInitTests: XCTestCase {
         state.signals = [LocalSignal(type: .stdLogic, name: .x), LocalSignal(type: .stdLogic, name: .y)]
         var expected = state
         state.actions[.onEntry] = .blocks(blocks: [
-            .statement(statement: .assignment(name: .variable(name: .x), value: y)),
+            .statement(statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)),
             .statement(statement: .assignment(
-                name: .variable(name: .z), value: .literal(value: .boolean(value: true))
+                name: .variable(reference: .variable(name: .z)),
+                value: .literal(value: .boolean(value: true))
             )),
             .statement(statement: .assignment(
-                name: .variable(name: .y), value: .literal(value: .logic(value: .high))
+                name: .variable(reference: .variable(name: .y)), value: .literal(value: .logic(value: .high))
             ))
         ])
         expected.actions[.onEntry] = .blocks(blocks: [
-            .statement(statement: .assignment(name: .variable(name: newX), value: expNewY)),
             .statement(statement: .assignment(
-                name: .variable(name: .z), value: .literal(value: .boolean(value: true))
+                name: .variable(reference: .variable(name: newX)), value: expNewY
             )),
             .statement(statement: .assignment(
-                name: .variable(name: newY), value: .literal(value: .logic(value: .high))
+                name: .variable(reference: .variable(name: .z)), value: .literal(value: .boolean(value: true))
+            )),
+            .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: newY)),
+                value: .literal(value: .logic(value: .high))
             ))
         ])
         let result = State(replacingStateVariablesIn: state)

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/StatementInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/StatementInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class StatementInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,21 +76,25 @@ final class StatementInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `assignment` name is replaced.
     func testAssignmentName() {
-        let original = Statement.assignment(name: .variable(name: .x), value: y)
+        let original = Statement.assignment(name: .variable(reference: .variable(name: .x)), value: y)
         let result = Statement(statement: original, replacing: .x, with: newX)
-        XCTAssertEqual(result, Statement.assignment(name: .variable(name: newX), value: y))
+        XCTAssertEqual(
+            result, Statement.assignment(name: .variable(reference: .variable(name: newX)), value: y)
+        )
     }
 
     /// Test `assignment` value is replaced.
     func testAssignmentValue() {
-        let original = Statement.assignment(name: .variable(name: .y), value: x)
+        let original = Statement.assignment(name: .variable(reference: .variable(name: .y)), value: x)
         let result = Statement(statement: original, replacing: .x, with: newX)
-        XCTAssertEqual(result, Statement.assignment(name: .variable(name: .y), value: expNewX))
+        XCTAssertEqual(
+            result, Statement.assignment(name: .variable(reference: .variable(name: .y)), value: expNewX)
+        )
     }
 
     /// Test `comment` does nothing.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/SynchronousBlockInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/SynchronousBlockInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class SynchronousBlockInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,19 +76,21 @@ final class SynchronousBlockInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test that all blocks are replaced correctly.
     func testBlock() {
         let original = SynchronousBlock.blocks(blocks: [
-            .statement(statement: .assignment(name: .variable(name: .x), value: y)),
-            .statement(statement: .assignment(name: .variable(name: .y), value: x))
+            .statement(statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)),
+            .statement(statement: .assignment(name: .variable(reference: .variable(name: .y)), value: x))
         ])
         let result = SynchronousBlock(block: original, replacing: .x, with: newX)
         XCTAssertEqual(result, SynchronousBlock.blocks(blocks: [
-            .statement(statement: .assignment(name: .variable(name: newX), value: y)),
-            .statement(statement: .assignment(name: .variable(name: .y), value: expNewX))
+            .statement(statement: .assignment(name: .variable(reference: .variable(name: newX)), value: y)),
+            .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: .y)), value: expNewX
+            ))
         ]))
     }
 
@@ -121,7 +123,8 @@ final class SynchronousBlockInitTests: XCTestCase {
         )
         let result = SynchronousBlock(block: original, replacing: .x, with: newX)
         XCTAssertEqual(
-            result, SynchronousBlock.ifStatement(
+            result,
+            SynchronousBlock.ifStatement(
                 block: .ifStatement(condition: expNewX, ifBlock: .statement(statement: .null))
             )
         )
@@ -129,10 +132,15 @@ final class SynchronousBlockInitTests: XCTestCase {
 
     /// Test statement.
     func testStatement() {
-        let original = SynchronousBlock.statement(statement: .assignment(name: .variable(name: .x), value: y))
+        let original = SynchronousBlock.statement(
+            statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)
+        )
         let result = SynchronousBlock(block: original, replacing: .x, with: newX)
         XCTAssertEqual(
-            result, SynchronousBlock.statement(statement: .assignment(name: .variable(name: newX), value: y))
+            result,
+            SynchronousBlock.statement(
+                statement: .assignment(name: .variable(reference: .variable(name: newX)), value: y)
+            )
         )
     }
 

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/TransitionConditionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/TransitionConditionInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class TransitionConditionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     /// An `x` variable.
     let xC = TransitionCondition.variable(name: .x)
@@ -82,7 +82,7 @@ final class TransitionConditionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// `newX` as a ``TransitionCondition``.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/VariableReferenceInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/VariableReferenceInitTests.swift
@@ -70,15 +70,15 @@ final class VariableReferenceInitTests: XCTestCase {
 
     /// Test `variable` case.
     func testVariable() {
-        let x = VariableReference.variable(name: .x)
+        let x = VariableReference.variable(reference: .variable(name: .x))
         let result = VariableReference(reference: x, replacing: .x, with: newX)
-        let expected = VariableReference.variable(name: newX)
+        let expected = VariableReference.variable(reference: .variable(name: newX))
         XCTAssertEqual(result, expected)
     }
 
     /// Test `variable` case when variable doesn't match.
     func testInvalidVariable() {
-        let x = VariableReference.variable(name: .x)
+        let x = VariableReference.variable(reference: .variable(name: .x))
         let result = VariableReference(reference: x, replacing: .y, with: newX)
         XCTAssertEqual(result, x)
     }

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/VectorIndexTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/VectorIndexTests.swift
@@ -1,0 +1,78 @@
+// VectorIndexTests.swift
+// VHDLMachines
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLMachines
+import VHDLParsing
+import XCTest
+
+/// Test class for `VectorIndex` extensions.
+final class VectorIndexTests: XCTestCase {
+
+    /// Test replace init.
+    func testReplaceInit() {
+        let original = VectorIndex.index(
+            value: .reference(variable: .variable(reference: .variable(name: .x)))
+        )
+        let replaceX = VectorIndex(index: original, replacing: .x, with: .xs)
+        let expected = VectorIndex.index(
+            value: .reference(variable: .variable(reference: .variable(name: .xs)))
+        )
+        XCTAssertEqual(replaceX, expected)
+        XCTAssertEqual(original, VectorIndex(index: original, replacing: .y, with: .clk))
+        XCTAssertEqual(VectorIndex.others, VectorIndex(index: .others, replacing: .y, with: .clk))
+    }
+
+}

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/VectorSizeInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/VectorSizeInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class VectorSizeInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class VectorSizeInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test the `downto` case.

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/WhenCaseInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/WhenCaseInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class WhenCaseInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,12 +76,14 @@ final class WhenCaseInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test that the condition gets changed.
     func testCondition() {
-        let code = SynchronousBlock.statement(statement: .assignment(name: .variable(name: .z), value: y))
+        let code = SynchronousBlock.statement(
+            statement: .assignment(name: .variable(reference: .variable(name: .z)), value: y)
+        )
         let original = WhenCase(condition: .expression(expression: x), code: code)
         let result = WhenCase(whenCase: original, replacing: .x, with: newX)
         XCTAssertEqual(result, WhenCase(condition: .expression(expression: expNewX), code: code))
@@ -89,7 +91,9 @@ final class WhenCaseInitTests: XCTestCase {
 
     /// Test that the code gets changed.
     func testCode() {
-        let code = SynchronousBlock.statement(statement: .assignment(name: .variable(name: .x), value: y))
+        let code = SynchronousBlock.statement(
+            statement: .assignment(name: .variable(reference: .variable(name: .x)), value: y)
+        )
         let original = WhenCase(condition: .expression(expression: y), code: code)
         let result = WhenCase(whenCase: original, replacing: .x, with: newX)
         XCTAssertEqual(
@@ -97,7 +101,7 @@ final class WhenCaseInitTests: XCTestCase {
             WhenCase(
                 condition: .expression(expression: y),
                 code: SynchronousBlock.statement(statement: .assignment(
-                    name: .variable(name: newX), value: y
+                    name: .variable(reference: .variable(name: newX)), value: y
                 ))
             )
         )

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/WhenConditionInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/WhenConditionInitTests.swift
@@ -62,10 +62,10 @@ import XCTest
 final class WhenConditionInitTests: XCTestCase {
 
     /// An `x` variable.
-    let x = Expression.reference(variable: .variable(name: .x))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: .x)))
 
     /// A `y` variable.
-    let y = Expression.reference(variable: .variable(name: .y))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: .y)))
 
     // swiftlint:disable force_unwrapping
 
@@ -76,7 +76,7 @@ final class WhenConditionInitTests: XCTestCase {
 
     /// `newX` as an expression.
     var expNewX: Expression {
-        .reference(variable: .variable(name: newX))
+        .reference(variable: .variable(reference: .variable(name: newX)))
     }
 
     /// Test `expression` case.


### PR DESCRIPTION
Update VHDLParsing to version 2.0.0. This PR changes the implementation to use the new structures in VHDLParsing 2.0.0.