### PR TITLE
Update VHDLParsing to version 2.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mipalgu/VHDLParsing",
       "state" : {
-        "revision" : "ae3976bd928f019b8fa786bf2182fc8806860bed",
-        "version" : "2.1.0"
+        "revision" : "49ffb700c06a1d6d2b8f82540608a16140e9c4f0",
+        "version" : "2.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "2.0.0"),
+        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "2.2.0"),
         .package(url: "https://github.com/mipalgu/GUUnits", from: "2.1.0"),
         .package(url: "https://github.com/mipalgu/swift_helpers", from: "2.0.0"),
         .package(url: "https://github.com/mipalgu/LLFSMModel", from: "1.0.0")

--- a/Sources/VHDLMachines/codeStructure/SynchronousBlock+allVariables.swift
+++ b/Sources/VHDLMachines/codeStructure/SynchronousBlock+allVariables.swift
@@ -192,7 +192,7 @@ extension VariableReference {
     @inlinable var allVariables: Set<VariableName> {
         switch self {
         case .indexed(let name, let index):
-            return index.allVariables.union([name])
+            return index.allVariables.union(name.allVariables)
         case .variable(let ref):
             return ref.allVariables
         }
@@ -370,7 +370,7 @@ extension FunctionCall {
     @inlinable var allVariables: Set<VariableName> {
         switch self {
         case .custom(let function):
-            return function.arguments.reduce(into: Set<VariableName>()) { $0 = $0.union($1.allVariables) }
+            return function.parameters.reduce(into: Set<VariableName>()) { $0 = $0.union($1.allVariables) }
                 .union([function.name])
         case .mathReal(let function):
             return function.arguments.reduce(into: Set<VariableName>()) { $0 = $0.union($1.allVariables) }
@@ -400,6 +400,19 @@ extension MathRealFunctionCalls {
         case .sqrt(let expression):
             return [expression]
         }
+    }
+
+}
+
+/// Add `allVariables`.
+extension Argument {
+
+    /// Return all the variables.
+    @inlinable var allVariables: Set<VariableName> {
+        guard let label = label else {
+            return self.argument.allVariables
+        }
+        return self.argument.allVariables.union([label])
     }
 
 }

--- a/Sources/VHDLMachines/codeStructure/replaceInits/FunctionCall+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/FunctionCall+replaceInit.swift
@@ -68,13 +68,19 @@ extension FunctionCall {
     init?(call: FunctionCall, replacing variable: VariableName, with value: VariableName) {
         switch call {
         case .custom(let function):
-            let newArguments = function.arguments.compactMap {
-                Expression(expression: $0, replacing: variable, with: value)
+            let newArguments: [Argument] = function.parameters.compactMap {
+                let newLabel = $0.label.flatMap { $0 == variable ? value : $0 }
+                guard
+                    let newArgument = Expression(expression: $0.argument, replacing: variable, with: value)
+                else {
+                    return nil
+                }
+                return Argument(label: newLabel, argument: newArgument)
             }
-            guard newArguments.count == function.arguments.count else {
+            guard newArguments.count == function.parameters.count else {
                 return nil
             }
-            self = .custom(function: CustomFunctionCall(name: function.name, arguments: newArguments))
+            self = .custom(function: CustomFunctionCall(name: function.name, parameters: newArguments))
         case .mathReal(let function):
             guard let newFunction = MathRealFunctionCalls(
                 function: function, replacing: variable, with: value

--- a/Sources/VHDLMachines/codeStructure/replaceInits/FunctionImplementation+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/FunctionImplementation+replaceInit.swift
@@ -79,7 +79,7 @@ extension FunctionImplementation {
         self.init(
             name: function.name == variable ? value : function.name,
             arguments: newArguments,
-            returnTube: newReturn,
+            returnType: newReturn,
             body: newBody
         )
     }

--- a/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/VariableReference+replaceInit.swift
@@ -68,14 +68,13 @@ extension VariableReference {
     init?(reference: VariableReference, replacing variable: VariableName, with value: VariableName) {
         switch reference {
         case .indexed(let name, let index):
-            guard let newIndex = VectorIndex(index: index, replacing: variable, with: value) else {
+            guard
+                let newIndex = VectorIndex(index: index, replacing: variable, with: value),
+                let newName = Expression(expression: name, replacing: variable, with: value)
+            else {
                 return nil
             }
-            guard name == variable else {
-                self = .indexed(name: name, index: newIndex)
-                return
-            }
-            self = .indexed(name: value, index: index)
+            self = .indexed(name: newName, index: newIndex)
         case .variable(let ref):
             self = .variable(reference: DirectReference(reference: ref, replacing: variable, with: value))
         }

--- a/Tests/VHDLMachinesTests/codeStructure/AllVariablesTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/AllVariablesTests.swift
@@ -79,7 +79,7 @@ final class AllVariablesTests: XCTestCase {
         )
         XCTAssertEqual(VectorSize.downto(upper: x, lower: y).allVariables, [.x, .y])
         XCTAssertEqual(VariableReference.variable(reference: .variable(name: .x)).allVariables, [.x])
-        XCTAssertEqual(VariableReference.indexed(name: .x, index: .index(value: y)).allVariables, [.x, .y])
+        XCTAssertEqual(VariableReference.indexed(name: x, index: .index(value: y)).allVariables, [.x, .y])
         XCTAssertEqual(EdgeCondition.falling(expression: x).allVariables, [.x])
         XCTAssertEqual(EdgeCondition.rising(expression: x).allVariables, [.x])
     }
@@ -150,8 +150,9 @@ final class AllVariablesTests: XCTestCase {
     /// Test function calls.
     func testFunctions() {
         XCTAssertEqual(
-            // swiftlint:disable:next force_unwrapping
-            FunctionCall.custom(function: CustomFunctionCall(function: "y", arguments: [x])!).allVariables,
+            FunctionCall.custom(function: CustomFunctionCall(
+                name: .y, parameters: [Argument(argument: x)]
+            )).allVariables,
             [.y, .x]
         )
         XCTAssertEqual(FunctionCall.mathReal(function: .ceil(expression: x)).allVariables, [.x])

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionCallsInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionCallsInitTests.swift
@@ -95,14 +95,20 @@ final class FunctionCallsInitTests: XCTestCase {
 
     /// Test `custom` case.
     func testCustom() {
-        let original = FunctionCall.custom(function: CustomFunctionCall(name: .y, arguments: [x]))
+        let original = FunctionCall.custom(function: CustomFunctionCall(
+            name: .y, parameters: [Argument(argument: x)]
+        ))
         let result = FunctionCall(call: original, replacing: .x, with: newX)
-        XCTAssertEqual(result, .custom(function: CustomFunctionCall(name: .y, arguments: [expNewX])))
+        XCTAssertEqual(result, .custom(function: CustomFunctionCall(
+            name: .y, parameters: [Argument(argument: expNewX)]
+        )))
     }
 
     /// Test `custom` does nothing for invalid variable.
     func testCustomDoesNothing() {
-        let original = FunctionCall.custom(function: CustomFunctionCall(name: .x, arguments: [y]))
+        let original = FunctionCall.custom(function: CustomFunctionCall(
+            name: .x, parameters: [Argument(argument: y)]
+        ))
         let result = FunctionCall(call: original, replacing: .x, with: newX)
         XCTAssertEqual(result, original)
     }

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionImplementationTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/FunctionImplementationTests.swift
@@ -68,7 +68,7 @@ final class FunctionImplementationTests: XCTestCase {
         let original = FunctionImplementation(
             name: .g,
             arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
-            returnTube: .alias(name: .z),
+            returnType: .alias(name: .z),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .a)))
             ))
@@ -77,7 +77,7 @@ final class FunctionImplementationTests: XCTestCase {
         let expected = FunctionImplementation(
             name: .clk,
             arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
-            returnTube: .alias(name: .z),
+            returnType: .alias(name: .z),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .a)))
             ))
@@ -87,7 +87,7 @@ final class FunctionImplementationTests: XCTestCase {
         let expected2 = FunctionImplementation(
             name: .g,
             arguments: [ArgumentDefinition(name: .xs, type: .alias(name: .y))],
-            returnTube: .alias(name: .z),
+            returnType: .alias(name: .z),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .a)))
             ))
@@ -97,7 +97,7 @@ final class FunctionImplementationTests: XCTestCase {
         let expected3 = FunctionImplementation(
             name: .g,
             arguments: [ArgumentDefinition(name: .x, type: .alias(name: .clk2))],
-            returnTube: .alias(name: .z),
+            returnType: .alias(name: .z),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .a)))
             ))
@@ -107,7 +107,7 @@ final class FunctionImplementationTests: XCTestCase {
         let expected4 = FunctionImplementation(
             name: .g,
             arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
-            returnTube: .alias(name: .command),
+            returnType: .alias(name: .command),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .a)))
             ))
@@ -117,7 +117,7 @@ final class FunctionImplementationTests: XCTestCase {
         let expected5 = FunctionImplementation(
             name: .g,
             arguments: [ArgumentDefinition(name: .x, type: .alias(name: .y))],
-            returnTube: .alias(name: .z),
+            returnType: .alias(name: .z),
             body: .statement(statement: .returns(
                 value: .reference(variable: .variable(reference: .variable(name: .internal)))
             ))

--- a/Tests/VHDLMachinesTests/codeStructure/replaceInits/VariableReferenceInitTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/replaceInits/VariableReferenceInitTests.swift
@@ -88,9 +88,13 @@ final class VariableReferenceInitTests: XCTestCase {
         let range = VectorIndex.range(value: .downto(
             upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
         ))
-        let x = VariableReference.indexed(name: .x, index: range)
+        let x = VariableReference.indexed(
+            name: .reference(variable: .variable(reference: .variable(name: .x))), index: range
+        )
         let result = VariableReference(reference: x, replacing: .x, with: newX)
-        let expected = VariableReference.indexed(name: newX, index: range)
+        let expected = VariableReference.indexed(
+            name: .reference(variable: .variable(reference: .variable(name: newX))), index: range
+        )
         XCTAssertEqual(result, expected)
     }
 
@@ -99,7 +103,9 @@ final class VariableReferenceInitTests: XCTestCase {
         let range = VectorIndex.range(value: .downto(
             upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
         ))
-        let x = VariableReference.indexed(name: .x, index: range)
+        let x = VariableReference.indexed(
+            name: .reference(variable: .variable(reference: .variable(name: .x))), index: range
+        )
         let result = VariableReference(reference: x, replacing: .y, with: newX)
         XCTAssertEqual(result, x)
     }


### PR DESCRIPTION
This PR updates VHDLParsing to version 2.2.0. Existing functions were marked `deprecated` in 2.2.0, and there use has thus been removed in this package.