### PR TITLE
Remove paths and names from models.

### DIFF
--- a/Sources/VHDLMachines/Arrangement.swift
+++ b/Sources/VHDLMachines/Arrangement.swift
@@ -31,14 +31,6 @@ public struct Arrangement: Equatable, Hashable, Codable {
     /// The clocks in the arrangement available to every machine.
     public var clocks: [Clock]
 
-    /// The parent machines in the arrangement. These machines act as entry points into the main program
-    /// of this arrangement.
-    public var parents: [VariableName]
-
-    /// The path to the arrangement. This is the path to the file containing the arrangement definition. This
-    /// path will be used to persist the arrangement.
-    public var path: URL
-
     /// Initialises the arrangement with the given values.
     /// - Parameters:
     ///   - machines: The machines in the arrangement.
@@ -52,41 +44,12 @@ public struct Arrangement: Equatable, Hashable, Codable {
         machines: [VariableName: URL],
         externalSignals: [PortSignal],
         signals: [LocalSignal],
-        clocks: [Clock],
-        parents: [VariableName],
-        path: URL
+        clocks: [Clock]
     ) {
         self.machines = machines
         self.externalSignals = externalSignals
         self.signals = signals
         self.clocks = clocks
-        self.parents = parents
-        self.path = path
-    }
-
-    /// Create an initial arrangement located at the given URL. This arrangement will contain a single machine
-    /// called *Machine* that will exist within the same directory as the arrangement folder.
-    /// - Parameter url: The URL to the arrangement folder.
-    /// - Returns: The initial arrangement.
-    @inlinable
-    public static func initial(url: URL) -> Arrangement? {
-        let machineURL = url.deletingLastPathComponent().appendingPathComponent(
-            "Machine.machine", isDirectory: true
-        )
-        guard
-            let newMachine = Machine.initial(path: machineURL), let name = VariableName(rawValue: "Machine")
-        else {
-            return nil
-        }
-        let clock = newMachine.clocks
-        return Arrangement(
-            machines: [name: machineURL],
-            externalSignals: [],
-            signals: [],
-            clocks: clock,
-            parents: [name],
-            path: url
-        )
     }
 
 }

--- a/Sources/VHDLMachines/VHDLCompiler.swift
+++ b/Sources/VHDLMachines/VHDLCompiler.swift
@@ -52,6 +52,7 @@ public struct VHDLCompiler {
 
     /// Generate the VHDL source code for a machine.
     /// - Parameter machine: The machine to compile.
+    /// - Parameter name: The name of the machine.
     /// - Returns: The VHDL source code.
     @inlinable
     func generateVHDLFile(machine: Machine, name: VariableName) -> String? {

--- a/Sources/VHDLMachines/VHDLCompiler.swift
+++ b/Sources/VHDLMachines/VHDLCompiler.swift
@@ -22,13 +22,19 @@ public struct VHDLCompiler {
 
     /// Compile a machine into a VHDL source file within the machine folder specified by the machines path.
     /// - Parameter machine: The machine to compile.
+    /// - Parameter url: The location to the machine folder. This url must end with a `.machine` extension.
     /// - Returns: Whether the compilation was successful.
     @inlinable
-    public func compile(_ machine: Machine) -> Bool {
-        guard let format = generateVHDLFile(machine) else {
+    public func compile(_ machine: Machine, location url: URL) -> Bool {
+        let name = url.lastPathComponent
+        guard
+            name.hasSuffix(".machine"),
+            let nameVar = VariableName(rawValue: String(name.dropLast(8))),
+            let format = generateVHDLFile(machine: machine, name: nameVar)
+        else {
             return false
         }
-        let fileName = "\(machine.name).vhd"
+        let fileName = "\(nameVar.rawValue).vhd"
         guard let data = format.data(using: .utf8) else {
             return false
         }
@@ -36,20 +42,20 @@ public struct VHDLCompiler {
         fileWrapper.preferredFilename = fileName
         let folderWrapper = FileWrapper(directoryWithFileWrappers: [fileName: fileWrapper])
         var isDirectory: ObjCBool = false
-        if manager.fileExists(atPath: machine.path.path, isDirectory: &isDirectory), isDirectory.boolValue {
-            guard (try? manager.removeItem(at: machine.path)) != nil else {
+        if manager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            guard (try? manager.removeItem(at: url)) != nil else {
                 return false
             }
         }
-        return (try? folderWrapper.write(to: machine.path, options: .atomic, originalContentsURL: nil)) != nil
+        return (try? folderWrapper.write(to: url, options: .atomic, originalContentsURL: nil)) != nil
     }
 
     /// Generate the VHDL source code for a machine.
     /// - Parameter machine: The machine to compile.
     /// - Returns: The VHDL source code.
     @inlinable
-    func generateVHDLFile(_ machine: Machine) -> String? {
-        guard let representation = MachineRepresentation(machine: machine) else {
+    func generateVHDLFile(machine: Machine, name: VariableName) -> String? {
+        guard let representation = MachineRepresentation(machine: machine, name: name) else {
             return nil
         }
         return VHDLFile(representation: representation).rawValue

--- a/Sources/VHDLMachines/VHDLGenerator.swift
+++ b/Sources/VHDLMachines/VHDLGenerator.swift
@@ -9,6 +9,7 @@ import Foundation
 #if os(Linux) || os(Windows)
 import SwiftUtils
 #endif
+import VHDLParsing
 
 /// A generator that can generate a `FileWrapper` from a ``Machine``.
 public struct VHDLGenerator {
@@ -21,7 +22,7 @@ public struct VHDLGenerator {
     /// - Parameter machine: The machine to generate a `FileWrapper` from.
     /// - Returns: The `FileWrapper` that represents the machine or nil if the machine could not be encoded.
     @inlinable
-    public func generate(machine: Machine) -> FileWrapper? {
+    public func generate(machine: Machine, with name: VariableName) -> FileWrapper? {
         let encoder = JSONEncoder()
         guard let data = try? encoder.encode(machine) else {
             return nil
@@ -29,7 +30,7 @@ public struct VHDLGenerator {
         let machineWrapper = FileWrapper(regularFileWithContents: data)
         machineWrapper.preferredFilename = "machine.json"
         let folderWrapper = FileWrapper(directoryWithFileWrappers: [:])
-        folderWrapper.preferredFilename = "\(machine.name).machine"
+        folderWrapper.preferredFilename = "\(name.rawValue).machine"
         _ = folderWrapper.addFileWrapper(machineWrapper)
         return folderWrapper
     }

--- a/Sources/VHDLMachines/VHDLGenerator.swift
+++ b/Sources/VHDLMachines/VHDLGenerator.swift
@@ -20,6 +20,7 @@ public struct VHDLGenerator {
 
     /// Generate a `FileWrapper` from a ``Machine``.
     /// - Parameter machine: The machine to generate a `FileWrapper` from.
+    /// - Parameter name: The name of the machine.
     /// - Returns: The `FileWrapper` that represents the machine or nil if the machine could not be encoded.
     @inlinable
     public func generate(machine: Machine, with name: VariableName) -> FileWrapper? {

--- a/Sources/VHDLMachines/codeStructure/Entity+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/Entity+machineInit.swift
@@ -62,7 +62,7 @@ extension Entity {
     /// Create the entity declaration for a machine.
     /// - Parameter machine: The machine to convert.
     @inlinable
-    init?(machine: Machine) {
+    init?(machine: Machine, name: VariableName) {
         let clocks = machine.clocks.map { PortSignal(clock: $0) }
         var signals: [PortSignal] = clocks + machine.externalSignals.map {
             PortSignal(
@@ -107,7 +107,7 @@ extension Entity {
         guard let port = PortBlock(signals: signals) else {
             return nil
         }
-        self.init(name: machine.name, port: port)
+        self.init(name: name, port: port)
     }
 
 }

--- a/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
+++ b/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
@@ -85,6 +85,7 @@ public struct MachineRepresentation: MachineVHDLRepresentable {
 
     /// Create the machine representation for the given machine.
     /// - Parameter machine: The machine to convert into a `VHDL` file.
+    /// - Parameter name: The name of the machine.
     public init?(machine: Machine, name: VariableName) {
         let representationVariables: [VariableName] = [
             .suspended, .internalState, .currentState, .previousRinglet, .suspendedFrom, .ringletLength,

--- a/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
+++ b/Sources/VHDLMachines/codeStructure/MachineRepresentation.swift
@@ -85,7 +85,7 @@ public struct MachineRepresentation: MachineVHDLRepresentable {
 
     /// Create the machine representation for the given machine.
     /// - Parameter machine: The machine to convert into a `VHDL` file.
-    public init?(machine: Machine) {
+    public init?(machine: Machine, name: VariableName) {
         let representationVariables: [VariableName] = [
             .suspended, .internalState, .currentState, .previousRinglet, .suspendedFrom, .ringletLength,
             .clockPeriod, .ringletPerPs, .ringletPerNs, .ringletPerUs, .ringletPerMs, .ringletPerS,
@@ -126,7 +126,7 @@ public struct MachineRepresentation: MachineVHDLRepresentable {
         }
         guard
             let newMachine = Machine(replacingStateRefsIn: machine),
-            let entity = Entity(machine: newMachine),
+            let entity = Entity(machine: newMachine, name: name),
             let architectureName = VariableName(rawValue: "Behavioral"),
             let head = ArchitectureHead(machine: newMachine),
             let body = AsynchronousBlock(machine: newMachine)

--- a/Sources/VHDLMachines/codeStructure/replaceInits/Machine+replaceInit.swift
+++ b/Sources/VHDLMachines/codeStructure/replaceInits/Machine+replaceInit.swift
@@ -74,13 +74,10 @@ extension Machine {
         }
         self.init(
             actions: machine.actions,
-            name: machine.name,
-            path: machine.path,
             includes: machine.includes,
             externalSignals: machine.externalSignals,
             clocks: machine.clocks,
             drivingClock: machine.drivingClock,
-            dependentMachines: machine.dependentMachines,
             machineSignals: machine.machineSignals,
             isParameterised: machine.isParameterised,
             parameterSignals: machine.parameterSignals,

--- a/Tests/TestUtils/Machine+testMachine.swift
+++ b/Tests/TestUtils/Machine+testMachine.swift
@@ -72,8 +72,6 @@ extension Machine {
         ))
         var machine = VHDLMachines.Machine(
             actions: [.onEntry, .internal, .onExit, .onResume, .onSuspend],
-            name: VariableName(rawValue: "TestMachine")!,
-            path: directory.appendingPathComponent("TestMachine.machine", isDirectory: true),
             includes: [
                 .library(value: VariableName(rawValue: "IEEE")!),
                 .include(statement: UseStatement(rawValue: "use IEEE.std_logic_1164.ALL;")!),
@@ -105,7 +103,6 @@ extension Machine {
                 Clock(name: VariableName.clk2, frequency: 20, unit: .kHz)
             ],
             drivingClock: 0,
-            dependentMachines: [:],
             machineSignals: [
                 LocalSignal(
                     type: .stdLogic,

--- a/Tests/TestUtils/PingPongArrangement.swift
+++ b/Tests/TestUtils/PingPongArrangement.swift
@@ -206,13 +206,10 @@ public struct PingPongArrangement {
     public var pingMachine: Machine {
         Machine(
             actions: [.onEntry, .onExit, .internal],
-            name: VariableName(rawValue: "PingMachine")!,
-            path: pingMachinePath,
             includes: includes,
             externalSignals: pingSignals,
             clocks: clocks,
             drivingClock: 0,
-            dependentMachines: [:],
             machineSignals: [],
             isParameterised: false,
             parameterSignals: [],
@@ -228,13 +225,10 @@ public struct PingPongArrangement {
     public var pongMachine: Machine {
         Machine(
             actions: [.onEntry, .onExit, .internal],
-            name: VariableName(rawValue: "PongMachine")!,
-            path: pongMachinePath,
             includes: includes,
             externalSignals: pongSignals,
             clocks: clocks,
             drivingClock: 0,
-            dependentMachines: [:],
             machineSignals: [],
             isParameterised: false,
             parameterSignals: [],
@@ -255,9 +249,7 @@ public struct PingPongArrangement {
             ],
             externalSignals: [],
             signals: [],
-            clocks: clocks,
-            parents: [VariableName(rawValue: "PingMachine")!, VariableName(rawValue: "PongMachine")!],
-            path: arrangementPath
+            clocks: clocks
         )
     }
 

--- a/Tests/TestUtils/VariableName+testConstants.swift
+++ b/Tests/TestUtils/VariableName+testConstants.swift
@@ -113,6 +113,8 @@ public extension VariableName {
 
     static var machineSignal2: VariableName { VariableName(rawValue: "machineSignal2")! }
 
+    static let testMachine = VariableName(rawValue: "TestMachine")!
+
 }
 
 // swiftlint:enable missing_docs

--- a/Tests/TestUtils/VariableName+testConstants.swift
+++ b/Tests/TestUtils/VariableName+testConstants.swift
@@ -99,6 +99,10 @@ public extension VariableName {
 
     static var pong: VariableName { VariableName(rawValue: "pong")! }
 
+    static let pingMachine = VariableName(rawValue: "PingMachine")!
+
+    static let pongMachine = VariableName(rawValue: "PongMachine")!
+
     static var parXs: VariableName { VariableName(rawValue: "parXs")! }
 
     static var retX: VariableName { VariableName(rawValue: "retX")! }

--- a/Tests/VHDLMachinesTests/ArrangementTests.swift
+++ b/Tests/VHDLMachinesTests/ArrangementTests.swift
@@ -113,9 +113,7 @@ final class ArrangementTests: XCTestCase {
         machines: machines,
         externalSignals: externalSignals,
         signals: signals,
-        clocks: clocks,
-        parents: parents,
-        path: path
+        clocks: clocks
     )
 
     /// Initialises the arrangement to test.
@@ -124,9 +122,7 @@ final class ArrangementTests: XCTestCase {
             machines: machines,
             externalSignals: externalSignals,
             signals: signals,
-            clocks: clocks,
-            parents: parents,
-            path: path
+            clocks: clocks
         )
     }
 
@@ -136,8 +132,6 @@ final class ArrangementTests: XCTestCase {
         XCTAssertEqual(self.arrangement.externalSignals, self.externalSignals)
         XCTAssertEqual(self.arrangement.signals, self.signals)
         XCTAssertEqual(self.arrangement.clocks, self.clocks)
-        XCTAssertEqual(self.arrangement.parents, self.parents)
-        XCTAssertEqual(self.arrangement.path, self.path)
     }
 
     /// Tests getters and setters update properties correctly.
@@ -174,60 +168,14 @@ final class ArrangementTests: XCTestCase {
         let newClocks = [
             Clock(name: VariableName.clk2, frequency: 100, unit: .MHz)
         ]
-        let newParents = [VariableName(rawValue: "M2")!]
-        let newPath = URL(fileURLWithPath: "/path/to/new/arrangement")
         self.arrangement.machines = newMachines
         self.arrangement.externalSignals = newExternalSignals
         self.arrangement.signals = newSignals
         self.arrangement.clocks = newClocks
-        self.arrangement.parents = newParents
-        self.arrangement.path = newPath
         XCTAssertEqual(self.arrangement.machines, newMachines)
         XCTAssertEqual(self.arrangement.externalSignals, newExternalSignals)
         XCTAssertEqual(self.arrangement.signals, newSignals)
         XCTAssertEqual(self.arrangement.clocks, newClocks)
-        XCTAssertEqual(self.arrangement.parents, newParents)
-        XCTAssertEqual(self.arrangement.path, newPath)
-    }
-
-    /// Test initial function creates default arrangement correctly.
-    func testInitial() {
-        let url = URL(fileURLWithPath: "Arrangement.arrangement", isDirectory: true)
-        let arrangement = Arrangement.initial(url: url)
-        let machineURL = URL(fileURLWithPath: "./Machine.machine", isDirectory: true)
-        guard let machine = Machine.initial(path: machineURL) else {
-            XCTFail("Failed to create machine!")
-            return
-        }
-        let expected = Arrangement(
-            machines: [VariableName(rawValue: "Machine")!: machineURL],
-            externalSignals: [],
-            signals: [],
-            clocks: machine.clocks,
-            parents: [VariableName(rawValue: "Machine")!],
-            path: url
-        )
-        #if os(macOS)
-        guard let arrangement else {
-            XCTFail("Failed to get arrangement.")
-            return
-        }
-        XCTAssertEqual(arrangement.clocks, expected.clocks)
-        XCTAssertEqual(arrangement.externalSignals, expected.externalSignals)
-        XCTAssertEqual(arrangement.machines.count, expected.machines.count)
-        arrangement.machines.keys.forEach {
-            guard let m0 = arrangement.machines[$0], let m1 = expected.machines[$0] else {
-                XCTFail("Failed to get machine.")
-                return
-            }
-            XCTAssertEqual(m0.absoluteString, m1.absoluteString)
-        }
-        XCTAssertEqual(arrangement.parents, expected.parents)
-        XCTAssertEqual(arrangement.path.absoluteString, expected.path.absoluteString)
-        XCTAssertEqual(arrangement.signals, expected.signals)
-        #else
-        XCTAssertEqual(arrangement, expected)
-        #endif
     }
 
     // swiftlint:enable force_unwrapping

--- a/Tests/VHDLMachinesTests/MachineTests.swift
+++ b/Tests/VHDLMachinesTests/MachineTests.swift
@@ -216,13 +216,10 @@ final class MachineTests: XCTestCase {
     /// The machine to test.
     lazy var machine = Machine(
         actions: actions,
-        name: machineName,
-        path: path,
         includes: includes,
         externalSignals: externalSignals,
         clocks: clocks,
         drivingClock: drivingClock,
-        dependentMachines: dependentMachines,
         machineSignals: machineSignals,
         isParameterised: true,
         parameterSignals: parameterSignals,
@@ -239,13 +236,10 @@ final class MachineTests: XCTestCase {
     override func setUp() {
         self.machine = Machine(
             actions: actions,
-            name: machineName,
-            path: path,
             includes: includes,
             externalSignals: externalSignals,
             clocks: clocks,
             drivingClock: drivingClock,
-            dependentMachines: dependentMachines,
             machineSignals: machineSignals,
             isParameterised: true,
             parameterSignals: parameterSignals,
@@ -261,13 +255,10 @@ final class MachineTests: XCTestCase {
 
     /// Test init sets the correct values.
     func testInit() {
-        XCTAssertEqual(machine.name, machineName)
-        XCTAssertEqual(machine.path, path)
         XCTAssertEqual(machine.includes, includes)
         XCTAssertEqual(machine.externalSignals, externalSignals)
         XCTAssertEqual(machine.clocks, clocks)
         XCTAssertEqual(machine.drivingClock, drivingClock)
-        XCTAssertEqual(machine.dependentMachines, dependentMachines)
         XCTAssertEqual(machine.machineSignals, machineSignals)
         XCTAssertTrue(machine.isParameterised)
         XCTAssertTrue(machine.isSuspensible)
@@ -286,8 +277,6 @@ final class MachineTests: XCTestCase {
 
     /// Test getters and setters work.
     func testGettersAndSetters() {
-        let newMachineName = VariableName(rawValue: "M3")!
-        let newPath = URL(fileURLWithPath: "/path/to/M3")
         let newIncludes = [
             Include.include(statement: UseStatement(rawValue: "use IEEE.STD_LOGIC_1164.ALL;")!)
         ]
@@ -305,7 +294,6 @@ final class MachineTests: XCTestCase {
             Clock(name: VariableName.clk2, frequency: 100, unit: .MHz)
         ]
         let newDrivingClock = 1
-        let newDependentMachines = [VariableName(rawValue: "M1")!: URL(fileURLWithPath: "/path/to/M1")]
         let newMachineSignals = [
             LocalSignal(
                 type: .stdLogic,
@@ -351,13 +339,10 @@ final class MachineTests: XCTestCase {
             name: .variable(reference: .variable(name: .g)),
             value: .expression(value: .literal(value: .bit(value: .low)))
         ))
-        machine.name = newMachineName
-        machine.path = newPath
         machine.includes = newIncludes
         machine.externalSignals = newExternalSignals
         machine.clocks = newClocks
         machine.drivingClock = newDrivingClock
-        machine.dependentMachines = newDependentMachines
         machine.machineSignals = newMachineSignals
         machine.parameterSignals = newParameterSignals
         machine.returnableSignals = newReturnableSignals
@@ -367,13 +352,10 @@ final class MachineTests: XCTestCase {
         machine.suspendedState = newSuspendedState
         machine.architectureHead = newArchitectureHead
         machine.architectureBody = newArchitectureBody
-        XCTAssertEqual(machine.name, newMachineName)
-        XCTAssertEqual(machine.path, newPath)
         XCTAssertEqual(machine.includes, newIncludes)
         XCTAssertEqual(machine.externalSignals, newExternalSignals)
         XCTAssertEqual(machine.clocks, newClocks)
         XCTAssertEqual(machine.drivingClock, newDrivingClock)
-        XCTAssertEqual(machine.dependentMachines, newDependentMachines)
         XCTAssertEqual(machine.machineSignals, newMachineSignals)
         XCTAssertEqual(machine.parameterSignals, newParameterSignals)
         XCTAssertEqual(machine.returnableSignals, newReturnableSignals)
@@ -386,13 +368,10 @@ final class MachineTests: XCTestCase {
     }
 
     /// Test initial machine is setup correctly.
-    func testInitial() {
-        let path = URL(fileURLWithPath: "NewMachine.machine", isDirectory: true)
-        let machine = Machine.initial(path: path)
+    func testInitialSuspensible() {
+        let machine = Machine.initialSuspensible
         let expected = Machine(
             actions: actions,
-            name: VariableName(rawValue: "NewMachine")!,
-            path: path,
             includes: [
                 .library(value: VariableName(rawValue: "IEEE")!),
                 .include(statement: UseStatement(rawValue: "use IEEE.std_logic_1164.All;")!),
@@ -401,7 +380,6 @@ final class MachineTests: XCTestCase {
             externalSignals: [],
             clocks: [Clock(name: VariableName.clk, frequency: 50, unit: .MHz)],
             drivingClock: 0,
-            dependentMachines: [:],
             machineSignals: [],
             isParameterised: false,
             parameterSignals: [],

--- a/Tests/VHDLMachinesTests/VHDLGeneratorTests.swift
+++ b/Tests/VHDLMachinesTests/VHDLGeneratorTests.swift
@@ -83,7 +83,7 @@ final class VHDLGeneratorTests: XCTestCase {
 
     /// Test Generate creates correct file structure.
     func testGenerate() {
-        guard let wrapper = generator.generate(machine: factory.pingMachine) else {
+        guard let wrapper = generator.generate(machine: factory.pingMachine, with: .pingMachine) else {
             XCTFail("Failed to create wrapper!")
             return
         }
@@ -111,16 +111,16 @@ final class VHDLGeneratorTests: XCTestCase {
     /// Test write creates correct file structure.
     func testWrite() throws {
         let machine = factory.pingMachine
-        guard let wrapper = generator.generate(machine: machine) else {
+        guard let wrapper = generator.generate(machine: machine, with: .pingMachine) else {
             XCTFail("Failed to create wrapper!")
             return
         }
         XCTAssertTrue(wrapper.isDirectory)
         XCTAssertEqual(wrapper.preferredFilename, "PingMachine.machine")
-        if manager.fileExists(atPath: machine.path.path) {
-            try manager.removeItem(at: machine.path)
-        }
         let path = factory.machinePath.appendingPathComponent("PingMachine.machine", isDirectory: true)
+        if manager.fileExists(atPath: path.path) {
+            try manager.removeItem(at: path)
+        }
         try wrapper.write(to: path, originalContentsURL: nil)
         defer {
             if manager.fileExists(atPath: path.path) {

--- a/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
+++ b/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
@@ -89,7 +89,7 @@ class VHDLMachinesCompilerTests: XCTestCase {
 
     /// Test can compile initial machine.
     func testInitialMachine() {
-        XCTAssertTrue(compiler.compile(machine))
+        XCTAssertTrue(compiler.compile(machine, location: testMachinePath))
     }
 
     /// Test compiler overwrite parent folder.
@@ -102,14 +102,11 @@ class VHDLMachinesCompilerTests: XCTestCase {
                 return
             }
         }
-        XCTAssertTrue(compiler.compile(machine))
+        XCTAssertTrue(compiler.compile(machine, location: testMachinePath))
     }
 
     /// Test compilation overwrites existing file.
     func testCompileWorksWhenFileIsPresent() {
-        print("Machine path:")
-        print(testMachinePath.path)
-        fflush(stdout)
         if !manager.fileExists(atPath: testMachinePath.path) {
             guard (
                 try? manager.createDirectory(at: testMachinePath, withIntermediateDirectories: false)
@@ -118,13 +115,13 @@ class VHDLMachinesCompilerTests: XCTestCase {
                 return
             }
         }
-        let vhdFile = testMachinePath.path + "/\(machine.name).vhd"
+        let vhdFile = testMachinePath.path + "/\(VariableName.testMachine.rawValue).vhd"
         if !manager.fileExists(atPath: vhdFile) {
             XCTAssertTrue(
                 manager.createFile(atPath: vhdFile, contents: "Test Data\n".data(using: .utf8))
             )
         }
-        XCTAssertTrue(compiler.compile(machine))
+        XCTAssertTrue(compiler.compile(machine, location: testMachinePath))
     }
 
     /// Test compilation creates intermediate folder.
@@ -138,8 +135,7 @@ class VHDLMachinesCompilerTests: XCTestCase {
         let newPath = subdir.appendingPathComponent(
             "PingMachine.machine", isDirectory: true
         )
-        machine.path = newPath
-        XCTAssertTrue(compiler.compile(machine))
+        XCTAssertTrue(compiler.compile(machine, location: newPath))
         var isDirectory: ObjCBool = false
         XCTAssertTrue(manager.fileExists(atPath: newPath.path, isDirectory: &isDirectory))
         XCTAssertTrue(isDirectory.boolValue)
@@ -148,7 +144,7 @@ class VHDLMachinesCompilerTests: XCTestCase {
     /// Test the VHDL code generation is correct for the Ping Machine.
     func testPingMachineCodeGeneration() {
         let machine = factory.pingMachine
-        guard let code = compiler.generateVHDLFile(machine) else {
+        guard let code = compiler.generateVHDLFile(machine: machine, name: .pingMachine) else {
             XCTFail("Failed to generate code.")
             return
         }
@@ -161,12 +157,12 @@ class VHDLMachinesCompilerTests: XCTestCase {
             _ = try? manager.removeItem(at: factory.pingMachinePath)
         }
         let machine = factory.pingMachine
-        XCTAssertTrue(compiler.compile(machine))
+        XCTAssertTrue(compiler.compile(machine, location: factory.pingMachinePath))
     }
 
     /// Test generated code matches expected.
     func testGenerateVHDLFile() {
-        guard let code = compiler.generateVHDLFile(machine) else {
+        guard let code = compiler.generateVHDLFile(machine: machine, name: .testMachine) else {
             XCTFail("Failed to generate vhdl file.")
             return
         }

--- a/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
+++ b/Tests/VHDLMachinesTests/VHDLMachinesCompilerTests.swift
@@ -38,7 +38,7 @@ class VHDLMachinesCompilerTests: XCTestCase {
 
     /// FileWrapper for the test machine.
     var testMachineFileWrapper: FileWrapper? {
-        VHDLGenerator().generate(machine: machine)
+        VHDLGenerator().generate(machine: machine, with: .testMachine)
     }
 
     // swiftlint:disable type_contents_order

--- a/Tests/VHDLMachinesTests/VHDLParserTests.swift
+++ b/Tests/VHDLMachinesTests/VHDLParserTests.swift
@@ -76,7 +76,7 @@ final class VHDLParserTests: XCTestCase {
     /// Test parse function works correctly.
     func testParse() throws {
         guard
-            let machineWrapper = generator.generate(machine: factory.pingMachine),
+            let machineWrapper = generator.generate(machine: factory.pingMachine, with: .pingMachine),
             let machine = parser.parse(wrapper: machineWrapper)
         else {
             XCTFail("Failed to parse machine.")

--- a/Tests/VHDLMachinesTests/codeStructure/EntityTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/EntityTests.swift
@@ -64,18 +64,15 @@ final class EntityTests: XCTestCase {
 
     /// Test machine init.
     func testMachineInit() {
-        guard
-            var machine = Machine.initial(
-                path: URL(fileURLWithPath: "/tmp/NewMachine.machine", isDirectory: false)
-            )
-        else {
+        var machine = Machine.initialSuspensible
+        guard let name = VariableName(rawValue: "NewMachine") else {
             XCTFail("Failed to create machine.")
             return
         }
         let original = PortSignal(type: .stdLogic, name: .x, mode: .input)
         let signal = PortSignal(type: .stdLogic, name: original.externalName, mode: .input)
         machine.externalSignals = [original]
-        guard let entity = Entity(machine: machine) else {
+        guard let entity = Entity(machine: machine, name: name) else {
             XCTFail("Failed to create entity from machine.")
             return
         }
@@ -103,7 +100,7 @@ final class EntityTests: XCTestCase {
     /// Test machine init when machine is parameterised.
     func testParameterisedMachine() {
         let machine = Machine.testMachine()
-        guard let entity = Entity(machine: machine) else {
+        guard let entity = Entity(machine: machine, name: .testMachine) else {
             XCTFail("Failed to create entity from machine.")
             return
         }

--- a/Tests/VHDLMachinesTests/codeStructure/MachineRepresentationTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/MachineRepresentationTests.swift
@@ -64,10 +64,10 @@ final class MachineRepresentationTests: XCTestCase {
     /// Test the machine initialiser creates the stored properties correctly.
     func testMachineInit() {
         let machine = Machine.testMachine()
-        let representation = MachineRepresentation(machine: machine)
+        let representation = MachineRepresentation(machine: machine, name: .testMachine)
         guard
             let newMachine = Machine(replacingStateRefsIn: machine),
-            let entity = Entity(machine: newMachine),
+            let entity = Entity(machine: newMachine, name: .testMachine),
             let name = VariableName(rawValue: "Behavioral"),
             let head = ArchitectureHead(machine: newMachine),
             let body = AsynchronousBlock(machine: newMachine)
@@ -88,7 +88,7 @@ final class MachineRepresentationTests: XCTestCase {
         var machine = Machine.testMachine()
         machine.externalSignals += [PortSignal(type: .stdLogic, name: .x, mode: .input)]
         machine.machineSignals += [LocalSignal(type: .stdLogic, name: .x)]
-        XCTAssertNil(MachineRepresentation(machine: machine))
+        XCTAssertNil(MachineRepresentation(machine: machine, name: .testMachine))
         machine = Machine.testMachine()
         guard let var1 = VariableName(rawValue: "duplicateVar") else {
             XCTFail("Failed to create test variables.")
@@ -96,13 +96,13 @@ final class MachineRepresentationTests: XCTestCase {
         }
         machine.states[0].signals = [LocalSignal(type: .stdLogic, name: var1)]
         machine.states[1].signals = [LocalSignal(type: .stdLogic, name: var1)]
-        let representation = MachineRepresentation(machine: machine)
+        let representation = MachineRepresentation(machine: machine, name: .testMachine)
         XCTAssertNotNil(representation)
         // representation?.architectureBody.rawValue.components(separatedBy: .newlines).forEach {
         //     print($0)
         // }
         machine.machineSignals += [LocalSignal(type: .stdLogic, name: var1)]
-        XCTAssertNil(MachineRepresentation(machine: machine))
+        XCTAssertNil(MachineRepresentation(machine: machine, name: .testMachine))
     }
 
 }

--- a/Tests/VHDLMachinesTests/codeStructure/VHDLFileTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/VHDLFileTests.swift
@@ -63,7 +63,9 @@ final class VHDLFileTests: XCTestCase {
 
     /// Test representation initialiser.
     func testRepresentationInit() {
-        guard let representation = MachineRepresentation(machine: Machine.testMachine()) else {
+        guard let representation = MachineRepresentation(
+            machine: Machine.testMachine(), name: .testMachine
+        ) else {
             XCTFail("Invalid data!")
             return
         }


### PR DESCRIPTION
This PR removes the `path` and `name` variable from `Arrangement` and `Machine`. The initial function is also replaced with static initial constants within the `Machine` struct. Within the `Arrangement` struct, the `initial` function is removed entirely along with the `parents` variable.